### PR TITLE
fix: fixed a bug where a very low rate_per_byte results in failed uploads

### DIFF
--- a/Backend/src/controllers/solana.controller.ts
+++ b/Backend/src/controllers/solana.controller.ts
@@ -73,7 +73,7 @@ export const initializeConfig = async (req: Request, res: Response) => {
     // For testing, adminPubkey is the wallet address (you sign from frontend)
     const initIx = await createInitializeConfigInstruction(
       adminKey,
-      solanaData?.RATE_PER_BYTE_PER_UNIT || 1,
+      solanaData?.RATE_PER_BYTE_PER_UNIT || 1000,
       solanaData?.MINIMUM_DURATION_UNIT || 30,
       adminKey
     );


### PR DESCRIPTION
the new deployment on railway uses defaults to a very low rate_per_byte unit which we're setting if the value from the DB is undefined (i.e. not set yet)

this PR addresses it.