### PR TITLE
fix: use correct JSON structure in the FUNDING.json file

### DIFF
--- a/FUNDING.json
+++ b/FUNDING.json
@@ -1,3 +1,7 @@
 {
-  "filecoin_address": "0x00c315187de7e0ade6f745f8cdd33209af1edb6d"
+  "drips": {
+    "filecoin": {
+      "ownedBy": "0x1ddee29aebc7ed652b295c909d42f8314ff6734b"
+    }
+  }
 }


### PR DESCRIPTION
i reached out to the devs at drips when i faced an issue trying to claim this repo and it fails with a weird error.

the issue was due to the previous JSON shape.