### PR TITLE
feat: add database queries for deposit expiration management

### DIFF
--- a/Backend/src/db/depositTable.ts
+++ b/Backend/src/db/depositTable.ts
@@ -1,9 +1,9 @@
-import { eq } from "drizzle-orm";
+import { and, eq, lte, sql } from "drizzle-orm";
 import { db } from "./db.js";
 import { depositAccount } from "./schema.js";
 
 /**
- *
+ * Get transactions related to a user addresss
  * @param wallet
  * @returns
  */
@@ -17,6 +17,114 @@ export const getUserHistory = async (wallet: string) => {
     return userFiles;
   } catch (err) {
     console.log("Error getting user history", err);
+    return null;
+  }
+};
+
+/**
+ * Find deposits that will expire in X days and haven't been warned yet
+ * @param daysUntilExpiration - Number of days before expiration to warn (default: 7)
+ * @returns Array of deposits that need warning emails
+ */
+export const getDepositsNeedingWarning = async (
+  daysUntilExpiration: number = 7,
+) => {
+  try {
+    const targetDate = new Date();
+    targetDate.setDate(targetDate.getDate() + daysUntilExpiration);
+    const targetDateString = targetDate.toISOString().split("T")[0];
+
+    const deposits = await db
+      .select()
+      .from(depositAccount)
+      .where(
+        and(
+          eq(depositAccount.deletionStatus, "active"),
+          lte(
+            sql`DATE(${depositAccount.expiresAt})`,
+            sql`DATE(${targetDateString})`,
+          ),
+          sql`${depositAccount.userEmail} IS NOT NULL`,
+          sql`${depositAccount.userEmail} != ''`,
+        ),
+      );
+
+    return deposits;
+  } catch (err) {
+    console.error("Error getting deposits needing warning:", err);
+    return null;
+  }
+};
+
+/**
+ * Find deposits that have already expired
+ * @returns Array of expired deposits
+ */
+export const getExpiredDeposits = async () => {
+  try {
+    const now = new Date().toISOString().split("T")[0];
+
+    const deposits = await db
+      .select()
+      .from(depositAccount)
+      .where(
+        and(
+          sql`DATE(${depositAccount.expiresAt}) < DATE(${now})`,
+          sql`${depositAccount.deletionStatus} IN ('active', 'warned')`,
+        ),
+      );
+
+    return deposits;
+  } catch (err) {
+    console.error("Error getting expired deposits:", err);
+    return null;
+  }
+};
+
+/**
+ * Update the deletion status of a deposit
+ * @param depositId - The ID of the deposit
+ * @param status - New deletion status ('active' | 'warned' | 'deleted')
+ * @returns Updated deposit record
+ */
+export const updateDeletionStatus = async (
+  depositId: number,
+  status: "active" | "warned" | "deleted",
+) => {
+  try {
+    const updated = await db
+      .update(depositAccount)
+      .set({ deletionStatus: status })
+      .where(eq(depositAccount.id, depositId))
+      .returning();
+
+    return updated[0] || null;
+  } catch (err) {
+    console.error("Error updating deletion status:", err);
+    return null;
+  }
+};
+
+/**
+ * Update the warningSentAt timestamp for a deposit
+ * @param depositId - The ID of the deposit
+ * @returns Updated deposit record
+ */
+export const updateWarningSentAt = async (depositId: number) => {
+  try {
+    const now = new Date().toISOString();
+    const updated = await db
+      .update(depositAccount)
+      .set({
+        warningSentAt: now,
+        deletionStatus: "warned",
+      })
+      .where(eq(depositAccount.id, depositId))
+      .returning();
+
+    return updated[0] || null;
+  } catch (err) {
+    console.error("Error updating warningSentAt:", err);
     return null;
   }
 };


### PR DESCRIPTION
added db accessors — `getDepositsNeedingWarning()`, `getExpiredDeposits()`, `updateDeletionStatus()`, and `updateWarningSentAt()` to manage the expiration lifecycle. queries properly filter for active deposits with emails when warning, and only grab active/warned deposits when checking for deletion.