### PR TITLE
feat(ui): add dark/light theme toggle, color‑mode aware headers; fix …

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -9,7 +9,7 @@
       name="description"
       content="Web site created using create-tsrouter-app"
     />
-    <link rel="apple-touch-icon" href="/logo192.png" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.json" />
     <title>Keep</title>
   </head>

--- a/ui/public/manifest.json
+++ b/ui/public/manifest.json
@@ -3,19 +3,9 @@
   "name": "Create TanStack App Sample",
   "icons": [
     {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
+      "src": "favicon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any"
     }
   ],
   "start_url": ".",

--- a/ui/src/components/theme-toggle.tsx
+++ b/ui/src/components/theme-toggle.tsx
@@ -1,0 +1,23 @@
+import { IconButton, useColorMode } from '@chakra-ui/react'
+import { MoonIcon, SunIcon } from '@phosphor-icons/react'
+
+export const ThemeToggle = () => {
+  const { colorMode, toggleColorMode } = useColorMode()
+
+  const isDark = colorMode === 'dark'
+
+  return (
+    <IconButton
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      onClick={toggleColorMode}
+      variant="ghost"
+      size="sm"
+      icon={isDark ? <SunIcon size={18} /> : <MoonIcon size={18} />}
+      color="var(--text-muted)"
+      _hover={{
+        bg: 'rgba(255, 255, 255, 0.05)',
+        color: 'var(--text-inverse)',
+      }}
+    />
+  )
+}

--- a/ui/src/layouts/app/header.tsx
+++ b/ui/src/layouts/app/header.tsx
@@ -1,6 +1,7 @@
 import { ConnectWallet } from '@/components/connect-wallet'
 import { useAuthContext } from '@/hooks/context/auth'
-import { Box, HStack, IconButton, Text } from '@chakra-ui/react'
+import { Box, HStack, IconButton, Text, useColorModeValue } from '@chakra-ui/react'
+import { ThemeToggle } from '@/components/theme-toggle'
 import { LinkBreakIcon, ListIcon, WalletIcon } from '@phosphor-icons/react'
 import { useState } from 'react'
 
@@ -27,10 +28,10 @@ export const Header = ({ onMenuOpen }: HeaderProps) => {
         alignItems="center"
         position="fixed"
         width={{ xl: '85%', lg: '80%', md: '100%', base: '100%' }}
-        background="rgba(8, 8, 8, 0.6)"
+        background={useColorModeValue('rgba(255, 255, 255, 0.85)', 'rgba(8, 8, 8, 0.6)')}
         backdropFilter="blur(12px)"
         zIndex="10"
-        borderBottom="1px solid rgba(255,255,255,0.05)"
+        borderBottom={`1px solid ${useColorModeValue('rgba(0,0,0,0.08)', 'rgba(255,255,255,0.05)')}`}
       >
         <Box display={{ base: 'block', md: 'block', lg: 'none' }}>
           <IconButton
@@ -46,14 +47,16 @@ export const Header = ({ onMenuOpen }: HeaderProps) => {
           />
         </Box>
 
-        <Box ml="auto">
+        <HStack ml="auto" spacing="0.6em" alignItems="center">
+          <ThemeToggle />
+          <Box>
           {isAuthenticated && user ? (
             <HStack
               height="40px"
               width="fit-content"
               px="1em"
-              bg="rgba(255,255,255,0.05)"
-              border="1px solid rgba(255,255,255,0.1)"
+              bg={useColorModeValue('rgba(0,0,0,0.04)', 'rgba(255,255,255,0.05)')}
+              border={`1px solid ${useColorModeValue('rgba(0,0,0,0.1)', 'rgba(255,255,255,0.1)')}`}
               borderRadius="full"
               justifyContent="space-between"
               spacing="0.75em"
@@ -88,8 +91,8 @@ export const Header = ({ onMenuOpen }: HeaderProps) => {
               px="1.5em"
               fontSize="var(--font-size-sm)"
               fontWeight="var(--font-weight-medium)"
-              bg="rgba(255,255,255,0.05)"
-              border="1px solid rgba(255,255,255,0.1)"
+              bg={useColorModeValue('rgba(0,0,0,0.06)', 'rgba(255,255,255,0.05)')}
+              border={`1px solid ${useColorModeValue('rgba(0,0,0,0.1)', 'rgba(255,255,255,0.1)')}`}
               color="var(--text-inverse)"
               backdropFilter="blur(5px)"
               borderRadius="full"
@@ -109,7 +112,8 @@ export const Header = ({ onMenuOpen }: HeaderProps) => {
               <Text>Connect Wallet</Text>
             </Box>
           )}
-        </Box>
+          </Box>
+        </HStack>
       </Box>
 
       <ConnectWallet

--- a/ui/src/layouts/home/header.tsx
+++ b/ui/src/layouts/home/header.tsx
@@ -1,5 +1,6 @@
 import { ConnectWallet } from '@/components/connect-wallet'
-import { Box, Button, Container, HStack, Text } from '@chakra-ui/react'
+import { Box, Button, Container, HStack, Text, useColorModeValue } from '@chakra-ui/react'
+import { ThemeToggle } from '@/components/theme-toggle'
 import {
   GithubLogoIcon,
   LinkBreakIcon,
@@ -28,9 +29,9 @@ export const HomeHeader = () => {
         right="0"
         height="80px"
         zIndex="100"
-        background="rgba(6, 7, 14, 0.6)"
+        background={useColorModeValue('rgba(255, 255, 255, 0.85)', 'rgba(8, 8, 8, 0.6)')}
         backdropFilter="blur(12px)"
-        borderBottom="1px solid rgba(255,255,255,0.05)"
+        borderBottom={`1px solid ${useColorModeValue('rgba(0,0,0,0.08)', 'rgba(255,255,255,0.05)')}`}
         transition="all 0.3s ease"
       >
         <Container maxW="container.xl" height="100%">
@@ -61,11 +62,12 @@ export const HomeHeader = () => {
             </Link>
 
             <HStack spacing="1.5em" alignItems="center">
+              <ThemeToggle />
               <Link to="/">
                 <Text
                   fontSize="var(--font-size-sm)"
                   fontWeight="500"
-                  color="var(--text-muted)"
+                  color={useColorModeValue('var(--gray-600)', 'var(--text-muted)')}
                   _hover={{ color: 'var(--text-inverse)' }}
                   transition="color 0.2s"
                   display={{ lg: 'block', md: 'block', base: 'none' }}
@@ -94,8 +96,8 @@ export const HomeHeader = () => {
                     height="40px"
                     width="fit-content"
                     px="1em"
-                    bg="rgba(255,255,255,0.05)"
-                    border="1px solid rgba(255,255,255,0.1)"
+                    bg={useColorModeValue('rgba(0,0,0,0.04)', 'rgba(255,255,255,0.05)')}
+                    border={`1px solid ${useColorModeValue('rgba(0,0,0,0.1)', 'rgba(255,255,255,0.1)')}`}
                     borderRadius="full"
                     justifyContent="space-between"
                   >
@@ -110,7 +112,7 @@ export const HomeHeader = () => {
                       as="span"
                       onClick={logout}
                       cursor="pointer"
-                      color="var(--text-muted)"
+                      color={useColorModeValue('var(--gray-600)', 'var(--text-muted)')}
                       _hover={{
                         color: 'var(--red-mead)',
                       }}
@@ -125,8 +127,8 @@ export const HomeHeader = () => {
                     px="1.5em"
                     fontSize="var(--font-size-sm)"
                     fontWeight="var(--font-weight-medium)"
-                    bg="rgba(255,255,255,0.05)"
-                    border="1px solid rgba(255,255,255,0.1)"
+                    bg={useColorModeValue('rgba(0,0,0,0.06)', 'rgba(255,255,255,0.05)')}
+                    border={`1px solid ${useColorModeValue('rgba(0,0,0,0.1)', 'rgba(255,255,255,0.1)')}`}
                     color="var(--text-inverse)"
                     backdropFilter="blur(5px)"
                     borderRadius="full"

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,4 +1,4 @@
-import { ChakraProvider } from '@chakra-ui/react'
+import { ChakraProvider, ColorModeScript } from '@chakra-ui/react'
 import { createRouter, RouterProvider } from '@tanstack/react-router'
 import { StrictMode } from 'react'
 import ReactDOM from 'react-dom/client'
@@ -10,6 +10,7 @@ import '../styles/_globals.scss'
 import { ToastProvider } from './components/toast.tsx'
 import { WalletProviders } from './context/auth-provider.tsx'
 import reportWebVitals from './reportWebVitals.ts'
+import { theme } from './theme'
 
 // Create a new router instance
 const router = createRouter({
@@ -35,7 +36,8 @@ if (rootElement && !rootElement.innerHTML) {
   root.render(
     <StrictMode>
       <WalletProviders>
-        <ChakraProvider>
+        <ChakraProvider theme={theme}>
+          <ColorModeScript initialColorMode={theme.config.initialColorMode} />
           <RouterProvider router={router} />
           <ToastProvider />
         </ChakraProvider>

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -1,0 +1,19 @@
+import { extendTheme } from '@chakra-ui/react'
+import type { ThemeConfig } from '@chakra-ui/react'
+
+const config: ThemeConfig = {
+  initialColorMode: 'dark',
+  useSystemColorMode: true,
+}
+
+export const theme = extendTheme({
+  config,
+  styles: {
+    global: (props: any) => ({
+      'html, body': {
+        background: props.colorMode === 'dark' ? '#080808' : '#f9fafb',
+        color: props.colorMode === 'dark' ? '#ffffff' : '#111827',
+      },
+    }),
+  },
+})

--- a/ui/styles/_variables.scss
+++ b/ui/styles/_variables.scss
@@ -159,3 +159,17 @@
   --z-popover: 1060;
   --z-tooltip: 1070;
 }
+
+html[data-theme='light'] {
+  --text-inverse: #111827;
+  --text-muted: #6b7280;
+
+  --bg-dark: #ffffff;
+  --bg-darker: #f9fafb;
+
+  --border-dark: #e5e7eb;
+  --border-hover: rgba(0, 0, 0, 0.08);
+
+  --code-block-bg: #f3f4f6;
+  --skeleton-bg: #0000001a;
+}


### PR DESCRIPTION
Adds a dark/light theme with a header toggle, color‑mode aware headers, and fixes for manifest icons and theme imports.

## Summary

This PR introduces a Chakra UI dark/light theme with a color mode toggle in both the home and app headers, ensuring consistent backgrounds, text, and borders across modes. It also resolves a `ThemeConfig` import runtime error and replaces missing PWA icon references with the existing `favicon.svg` to clear manifest warnings.

## Changes

- Configures global theme styles so background and text respond correctly to the active color mode.
- Adds a reusable theme toggle component and wires it into the home and app headers using `useColorModeValue` for proper contrast.
- Fixes `ThemeConfig` by converting it to a type-only import to avoid runtime issues.
- Updates `index.html` and `manifest.json` to use `favicon.svg` for Apple touch and PWA icons, removing invalid `logo192.png`/`logo512.png` references.
- Keeps routing behavior unchanged: the home page still renders under `HomeLayout` and app routes under `_layout`.

## Motivation

- Prevents blank/unstyled appearances caused by unresolved CSS variables during development and HMR.
- Ensures header content stays readable in light mode and visually consistent in dark mode.
- Eliminates console noise from invalid icon paths and incorrect theme imports.

## Verification

- Run `pnpm install` and `pnpm run dev` in `ui`.
- Open `http://localhost:3000/` and confirm:
  - Content renders with appropriate background and text for the active mode.
  - The sun/moon toggle switches themes; both headers update seamlessly.
  - No errors appear for `ThemeConfig` imports or PWA icons in the browser console.