### PR TITLE
fix: vercel deployment with workspace protocol

### DIFF
--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -1,4 +1,5 @@
 {
-  "buildCommand": "cd .. && pnpm install && cd sdk && pnpm build && cd ../ui && pnpm build",
+  "installCommand": "pnpm install --no-frozen-lockfile",
+  "buildCommand": "pnpm build",
   "rewrites": [{ "source": "/(.*)", "destination": "/" }]
 }


### PR DESCRIPTION
added installCommand to handle workspace:* resolution on vercel. when pnpm can't find the workspace context during deployment, it automatically falls back to fetching the published package from npm.

this keeps local dev using workspace symlinks while vercel uses the published storacha-sol@version from npm.