### PR TITLE
fix: sdk package.json exports for vite compatibility

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.7](https://github.com/seetadev/storacha-solana-sdk/compare/v0.0.4...v0.0.7) (2026-01-05)
+
+
+### Features
+
+* add extend_storage instruction to server and SDK ([#74](https://github.com/seetadev/storacha-solana-sdk/issues/74)) ([c9dacd7](https://github.com/seetadev/storacha-solana-sdk/commit/c9dacd78aef6d047f1c4ee199018ea176df7c939))
+* add extend_storage_duration instruction to contract  ([#72](https://github.com/seetadev/storacha-solana-sdk/issues/72)) ([9d94fa3](https://github.com/seetadev/storacha-solana-sdk/commit/9d94fa3f5fea1deefde0ec5633f5e163266fbcda))
+* add renewal page skeleton and deprecate deposit terminology ([e05718a](https://github.com/seetadev/storacha-solana-sdk/commit/e05718afe55a13fffeaf4a9617ef4308c5a13cf2))
+* add renewal page skeleton and deprecate deposit terminology  ([#69](https://github.com/seetadev/storacha-solana-sdk/issues/69)) ([867e8f5](https://github.com/seetadev/storacha-solana-sdk/commit/867e8f58a6e75072201c4388fcc157a66df2cb8a))
+* add SDK methods for storage renewal ([#61](https://github.com/seetadev/storacha-solana-sdk/issues/61)) ([59e3c7c](https://github.com/seetadev/storacha-solana-sdk/commit/59e3c7cc8a8bbfcb96dc5618469e517273ec03bf))
+* add storage renewal endpoints and database logic ([6e56bf3](https://github.com/seetadev/storacha-solana-sdk/commit/6e56bf3dce19b6abb2264c3127b59ee522ee1a3c))
+* add transaction history tracking + naming clarity improvements ([d071efa](https://github.com/seetadev/storacha-solana-sdk/commit/d071efa5b79955d80a3beaf2a16c3fcb760427bb))
+* add transaction history tracking + naming clarity improvements ([#66](https://github.com/seetadev/storacha-solana-sdk/issues/66)) ([10b5007](https://github.com/seetadev/storacha-solana-sdk/commit/10b5007290284a4799a86783c46550fe1c3417d7))
+* **docs:** setup docs with mintlify ([#87](https://github.com/seetadev/storacha-solana-sdk/issues/87)) ([3ebb3b0](https://github.com/seetadev/storacha-solana-sdk/commit/3ebb3b0bdb9594f5a201f83af3f53378dfd73d42))
+* get realtime SOL/USD price with the hermes client ([#88](https://github.com/seetadev/storacha-solana-sdk/issues/88)) ([0045430](https://github.com/seetadev/storacha-solana-sdk/commit/00454303c7c963cc3d8d2ebb092974f1dbc3e88a))
+* new UI for keep ([#75](https://github.com/seetadev/storacha-solana-sdk/issues/75)) ([36aea3d](https://github.com/seetadev/storacha-solana-sdk/commit/36aea3daee5e1813b73482dca24b2579d4675ea5))
+* run deletion job for expired file uploads ([#58](https://github.com/seetadev/storacha-solana-sdk/issues/58)) ([8caf5b5](https://github.com/seetadev/storacha-solana-sdk/commit/8caf5b5998d559e462a72c112af9517453d59082))
+* update config table to use our pricing model ([#90](https://github.com/seetadev/storacha-solana-sdk/issues/90)) ([3ff31b5](https://github.com/seetadev/storacha-solana-sdk/commit/3ff31b5c3d78631f414db2411ddb315491e29168))
+
+
+### Bug Fixes
+
+* fixed ui deployment issue related to vite ([19d3a08](https://github.com/seetadev/storacha-solana-sdk/commit/19d3a08d19528738029b6a242bbf834b17436cbe))
+* safely access NODE_ENV because the sdk requires it ([ef649fd](https://github.com/seetadev/storacha-solana-sdk/commit/ef649fd932ffb70897ad349dbe297d7906271310))
+* **solana:** return user friendly error on duplicate file upload ([#71](https://github.com/seetadev/storacha-solana-sdk/issues/71)) ([e668f4b](https://github.com/seetadev/storacha-solana-sdk/commit/e668f4b81760a2487a4ef458a5b9c4c1291e01f1))
+* **solana:** return user friendly error on duplicate file upload ([#71](https://github.com/seetadev/storacha-solana-sdk/issues/71)) ([0239aa7](https://github.com/seetadev/storacha-solana-sdk/commit/0239aa70ce1a2ebe5243eb7e54a221fb8c0cb6fe))
+* vercel deployment with workspace protocol ([#92](https://github.com/seetadev/storacha-solana-sdk/issues/92)) ([9feeb91](https://github.com/seetadev/storacha-solana-sdk/commit/9feeb9119ca00ae0b2e45c463a50239032ed2356))
+
 ### [0.0.6](https://github.com/seetadev/storacha-solana-sdk/compare/v0.0.4...v0.0.6) (2026-01-05)
 
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storacha-sol",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsup src/index.ts --minify",
@@ -9,12 +9,11 @@
     "knip": "knip"
   },
   "exports": {
-    "import": {
-      "node": "./dist/index.cjs",
-      "browser": "./dist/index.js",
-      "default": "./dist/index.js"
-    },
-    "require": "./dist/index.cjs"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
   },
   "files": [
     "dist",


### PR DESCRIPTION
fixed exports field structure - vite was failing to resolve the package because 'import.node' was pointing to .cjs instead of .js. esm imports (via 'import') should use .js for both node and browser, while commonjs (via 'require') uses .cjs.

changed from nested conditions to flat structure with proper order:
- types first (for typescript)
- import -> .js (esm for both node and browser)
- require -> .cjs (commonjs for legacy node)

published as storacha-sol@0.0.7