### PR TITLE
feat: sort user uploads by most recent first

### DIFF
--- a/server/src/db/uploads-table.ts
+++ b/server/src/db/uploads-table.ts
@@ -25,7 +25,6 @@ export const getUserHistory = async (wallet: string) => {
       .where(eq(uploads.depositKey, userAddres))
       .orderBy(desc(uploads.createdAt));
 
-      console.log(userFiles)
     return userFiles;
   } catch (err) {
     console.log("Error getting user history", err);


### PR DESCRIPTION
This PR fixes #82 , the upload history ordering by sorting results on the server using the createdAt timestamp in descending order.

Users will now see their most recent uploads first instead of FIFO order.