### PR TITLE
feat: group expiry warning emails + multi‑renew UI

### DIFF
--- a/ui/src/routes/renew.tsx
+++ b/ui/src/routes/renew.tsx
@@ -18,6 +18,7 @@ export const Route = createFileRoute('/renew')({
   validateSearch: (search: Record<string, unknown>) => {
     return {
       cid: (search.cid as string) || '',
+      cids: (search.cids as string) || '',
     }
   },
 })


### PR DESCRIPTION
This PR implements issue #110 by grouping expiry warnings per payer and updating the renewal UI to handle multiple expiring uploads.

Backend:
- Group deposits by userEmail and send one email per payer (instead of N emails).
- Only include active uploads with expiresAt <= 7 days, >= today, and warningSentAt IS NULL.
- Bulk-update warningSentAt/deletionStatus for all uploads in the grouped email.
- New grouped email template listing all expiring uploads.

UI:
- /renew now supports multiple expiring uploads via a tabbed selector.
- Works without cid, and accepts ?cids=cid1,cid2 for direct linking.
