### PR TITLE
fix(ui): allow custom storage durations and validate input as string

### DIFF
--- a/ui/src/components/duration-selector.tsx
+++ b/ui/src/components/duration-selector.tsx
@@ -32,8 +32,8 @@ const STORAGE_OPTIONS: Array<StorageOption> = [
 ]
 
 interface StorageDurationSelectorProps {
-  selectedDuration: number
-  onDurationChange: (duration: number) => void
+  selectedDuration: string
+  onDurationChange: (duration: string) => void
   email?: string
   onEmailChange?: (email: string) => void
 }
@@ -62,29 +62,29 @@ export const StorageDurationSelector = ({
           {STORAGE_OPTIONS.map((option) => (
             <Box
               key={option.duration}
-              onClick={() => onDurationChange(option.duration)}
+              onClick={() => onDurationChange(option.duration.toString())}
               p="1em"
               border="1px solid"
               borderColor={
-                selectedDuration === option.duration
+                selectedDuration === option.duration.toString()
                   ? 'var(--primary-500)'
                   : 'var(--border-hover)'
               }
               borderRadius="var(--radius-md)"
               cursor="pointer"
               bg={
-                selectedDuration === option.duration
+                selectedDuration === option.duration.toString()
                   ? 'rgba(249, 115, 22, 0.08)'
                   : 'var(--bg-dark)'
               }
               transition="all 0.2s ease"
               _hover={{
                 borderColor:
-                  selectedDuration === option.duration
+                  selectedDuration === option.duration.toString()
                     ? 'var(--primary-500)'
                     : 'var(--border-hover)',
                 bg:
-                  selectedDuration === option.duration
+                  selectedDuration === option.duration.toString()
                     ? 'rgba(249, 115, 22, 0.12)'
                     : 'var(--lght-grey)',
               }}
@@ -116,12 +116,20 @@ export const StorageDurationSelector = ({
             Custom:
           </Text>
           <Input
-            type="number"
+            type="text"
             placeholder="Days"
             value={selectedDuration}
             onChange={(e) => {
-              const value = parseInt(e.target.value, 10)
-              if (!isNaN(value) && value > 0) {
+              const value = e.target.value
+
+              // Allow empty string (so backspace works)
+              if (value === '') {
+                onDurationChange('')
+                return
+              }
+
+              // Allow digits only
+              if (/^[0-9]+$/.test(value)) {
                 onDurationChange(value)
               }
             }}

--- a/ui/src/containers/app/upload.tsx
+++ b/ui/src/containers/app/upload.tsx
@@ -22,14 +22,20 @@ export const Upload = () => {
   const { publicKey, signTransaction } = useWallet()
   const { price: solPrice } = useSolPrice()
   const [selectedFiles, setSelectedFiles] = useState<Array<File>>([])
-  const [storageDuration, setStorageDuration] = useState(30)
+  const [storageDuration, setStorageDuration] = useState<string>('30')
   const [email, setEmail] = useState('')
   const [state, setState] = useState<State>('idle')
+
+  const parsedDuration = Number(storageDuration)
+  const isValidDuration =
+    storageDuration !== '' &&
+    Number.isInteger(parsedDuration) &&
+    parsedDuration > 0
 
   const client = useDeposit(network)
   const { totalCost, isLoading: isCostLoading } = useStorageCost(
     selectedFiles,
-    storageDuration,
+    isValidDuration ? parsedDuration : 0,
   )
 
   useEffect(() => {
@@ -43,6 +49,11 @@ export const Upload = () => {
   }
 
   const handleUpload = async () => {
+    if (!isValidDuration) {
+      toast.error('Please enter a valid number of storage days')
+      return
+    }
+
     if (!publicKey || !signTransaction || selectedFiles.length === 0) {
       toast.error('Wallet not properly connected or no files selected')
       return
@@ -54,7 +65,7 @@ export const Upload = () => {
     try {
       const result = await client.createDeposit({
         file: selectedFiles,
-        durationDays: storageDuration,
+        durationDays: parsedDuration,
         payer: publicKey,
         signTransaction: async (tx: Transaction) => {
           toast.loading('Please sign the transaction in your wallet...', {
@@ -263,15 +274,15 @@ export const Upload = () => {
             borderRadius="var(--radius-lg)"
             transition="all 0.2s ease"
             _hover={{
-              bg: isUploadDisabled ? undefined : 'var(--primary-600)',
+              bg: isUploadDisabled ? undefined : 'var(--text-inverse)',
               transform: isUploadDisabled ? 'none' : 'translateY(-1px)',
               boxShadow: isUploadDisabled
                 ? undefined
-                : '0 4px 12px rgba(249, 115, 22, 0.4), 0 0 20px rgba(249, 115, 22, 0.2)',
+                : '0 4px 12px rgba(24, 24, 23, 0.4), 0 0 20px rgba(249, 115, 22, 0.2)',
             }}
             _active={{
               transform: isUploadDisabled ? 'none' : 'translateY(0)',
-              bg: isUploadDisabled ? undefined : 'var(--primary-700)',
+              bg: isUploadDisabled ? undefined : 'var(--text-inverse)',
             }}
             _disabled={{
               bg: 'var(--bg-dark)',


### PR DESCRIPTION
Allow flexible storage duration input (remove 7-day UI restriction). closes #83 
- Remove implicit minimum storage duration restriction
- Treat storage duration as string for better UX
- Add validation with user-facing toast errors
- Prevent invalid uploads while allowing full input flexibility

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/03f14200-49fd-4443-8248-714d6a3ae4b6" />
