### PR TITLE
fix: resolve deployment errors in ui hooks and server dependencies

### DIFF
--- a/ui/src/hooks/renewal.ts
+++ b/ui/src/hooks/renewal.ts
@@ -26,8 +26,8 @@ export const useFileDetails = (walletAddress: string, cid: string) => {
     walletAddress && cid ? ['file-details', walletAddress, cid, network] : null
 
   const { data, error, isLoading } = useSWR(key, async () => {
-    const response = await client.getUserUploadHistory(walletAddress)
-    const file = response.userHistory?.find((f: any) => f.contentCid === cid)
+    const response = await client.getUserUploadHistory(walletAddress, 1, 100)
+    const file = response.data?.find((f: any) => f.contentCid === cid)
 
     if (!file) {
       throw new Error('File not found in your upload history')

--- a/ui/src/hooks/upload-history.ts
+++ b/ui/src/hooks/upload-history.ts
@@ -12,11 +12,9 @@ export function useUploadHistory() {
     async () => {
       if (!user) return null
 
-      const historyData = await client.getUserUploadHistory(user)
-      // TODO: Fix according to new response structure after package update
-      // const historyData = await client.getUserUploadHistory(user, 1, 20)
+      const historyData = await client.getUserUploadHistory(user, 1, 20)
 
-      if (!historyData.userHistory || historyData.userHistory.length === 0) {
+      if (!historyData.data || historyData.data.length === 0) {
         return {
           files: [],
           stats: {
@@ -28,8 +26,8 @@ export function useUploadHistory() {
         }
       }
 
-      const transformedFiles: Array<UploadedFile> = historyData.userHistory.map(
-        (deposit) => {
+      const transformedFiles: Array<UploadedFile> = historyData.data.map(
+        (deposit: any) => {
           let status: 'active' | 'expired' | 'pending' = 'active'
           if (deposit.deletionStatus === 'deleted') {
             status = 'expired'


### PR DESCRIPTION
the deployment on vercel failed due to our recent change in the API structure (see [here](https://github.com/seetadev/Storacha-Solana-SDK/pull/129/changes#diff-3458d39404306a61639ffa28a02284e20ecd44dd022a87540650750ad2400b25R248)), so i updated upload-history and renewal hooks to use the correct sdk properties with pagination params (page, limit).