### PR TITLE
feat: add usage/capability reports via emails

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,58 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
+  console-ui:
+    dependencies:
+      '@chakra-ui/react':
+        specifier: ^2.10.4
+        version: 2.10.9(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(framer-motion@11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@emotion/react':
+        specifier: ^11.14.0
+        version: 11.14.0(@types/react@18.3.27)(react@18.3.1)
+      '@emotion/styled':
+        specifier: ^11.14.0
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
+      '@tanstack/react-router':
+        specifier: ^1.96.3
+        version: 1.144.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      framer-motion:
+        specifier: ^11.15.0
+        version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      recharts:
+        specifier: ^2.15.0
+        version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      swr:
+        specifier: ^2.2.5
+        version: 2.3.8(react@18.3.1)
+    devDependencies:
+      '@tanstack/router-devtools':
+        specifier: ^1.96.3
+        version: 1.157.14(@tanstack/react-router@1.144.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.144.0)(csstype@3.2.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/router-plugin':
+        specifier: ^1.96.2
+        version: 1.145.4(@tanstack/react-router@1.144.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.4.1(@types/node@24.10.4)(jiti@2.6.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/react':
+        specifier: ^18.3.18
+        version: 18.3.27
+      '@types/react-dom':
+        specifier: ^18.3.5
+        version: 18.3.7(@types/react@18.3.27)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.1(@types/node@24.10.4)(jiti@2.6.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.3
+      vite:
+        specifier: ^6.0.7
+        version: 6.4.1(@types/node@24.10.4)(jiti@2.6.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
   sdk:
     dependencies:
       '@solana/kit':
@@ -207,7 +259,7 @@ importers:
         version: 1.145.4(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@toju.network/sol':
         specifier: ^0.1.1
-        version: 0.1.1(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+        version: 0.1.1(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       framer-motion:
         specifier: ^11.11.17
         version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2058,6 +2110,9 @@ packages:
   '@reown/appkit@1.7.2':
     resolution: {integrity: sha512-oo/evAyVxwc33i8ZNQ0+A/VE6vyTyzL3NBJmAe3I4vobgQeiobxMM0boKyLRMMbJggPn8DtoAAyG4GfpKaUPzQ==}
 
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
 
@@ -3032,6 +3087,18 @@ packages:
       '@tanstack/router-core':
         optional: true
 
+  '@tanstack/react-router-devtools@1.157.14':
+    resolution: {integrity: sha512-UjNLZDHtCwamfzQxjcZ9xjohyMDGBx6oZAubD+ClpotlXCHEBPShqKXalN4DhWZxgDQtY3X2lxJ2IkhhWzSzIA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@tanstack/react-router': ^1.157.14
+      '@tanstack/router-core': ^1.157.14
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+    peerDependenciesMeta:
+      '@tanstack/router-core':
+        optional: true
+
   '@tanstack/react-router@1.144.0':
     resolution: {integrity: sha512-GmRyIGmHtGj3VLTHXepIwXAxTcHyL5W7Vw7O1CnVEtFxQQWKMVOnWgI7tPY6FhlNwMKVb3n0mPFWz9KMYyd2GA==}
     engines: {node: '>=12'}
@@ -3056,6 +3123,28 @@ packages:
       '@tanstack/router-core': ^1.144.0
       csstype: ^3.0.10
       solid-js: '>=1.9.5'
+    peerDependenciesMeta:
+      csstype:
+        optional: true
+
+  '@tanstack/router-devtools-core@1.157.14':
+    resolution: {integrity: sha512-mYUPbfB5ZrzSsftTxw2UdcGMwYxM1zLv4/y4flzg7TgAGIK7zPPplNC/Sj/ex240k9BdhZ9bo7n7WyACBrkkvA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@tanstack/router-core': ^1.157.14
+      csstype: ^3.0.10
+    peerDependenciesMeta:
+      csstype:
+        optional: true
+
+  '@tanstack/router-devtools@1.157.14':
+    resolution: {integrity: sha512-refrkjUIIAPNqcmW+GXXGRv4jtcwbYtxs7T8JmF8eOxT2kNDIVsMT9gkAwfVBNlT54kdgY/MG+tcMtamUm0rRw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@tanstack/react-router': ^1.157.14
+      csstype: ^3.0.10
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
     peerDependenciesMeta:
       csstype:
         optional: true
@@ -3288,6 +3377,33 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -3366,16 +3482,27 @@ packages:
   '@types/pg@8.16.0':
     resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+
+  '@types/react@18.3.27':
+    resolution: {integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==}
 
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
@@ -3599,6 +3726,12 @@ packages:
 
   '@upstash/qstash@2.8.4':
     resolution: {integrity: sha512-iojHWUlRoC3M2e4XQ1NFEgC+7Orurrm5uIrPn5WilU7LvWQoocyjYBXR0VUalXkeMAmFyk4blF0EOYZY4igdIQ==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitejs/plugin-react@5.1.2':
     resolution: {integrity: sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==}
@@ -4598,6 +4731,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   dargs@7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
     engines: {node: '>=8'}
@@ -4640,6 +4817,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -4744,6 +4924,9 @@ packages:
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   domain-browser@4.22.0:
     resolution: {integrity: sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==}
@@ -5193,6 +5376,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
@@ -5674,6 +5861,10 @@ packages:
 
   interface-store@6.0.3:
     resolution: {integrity: sha512-+WvfEZnFUhRwFxgz+QCQi7UC6o9AM0EHM9bpIe2Nhqb100NHCsTvNAn4eJgvgV2/tmLo1MP9nGxQKEcZTAueLA==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -7188,6 +7379,11 @@ packages:
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
@@ -7250,6 +7446,10 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
@@ -7274,6 +7474,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -7283,6 +7489,16 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
@@ -7330,6 +7546,16 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -7474,6 +7700,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -8144,6 +8373,11 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -8386,6 +8620,9 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
   viem@2.23.2:
     resolution: {integrity: sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==}
     peerDependencies:
@@ -8411,6 +8648,46 @@ packages:
     resolution: {integrity: sha512-GA9QKLH+vIM8NPaGA+o2t8PDfFUl32J8rUp1zQfMKVJQiNkOX4unE51tR6ppl6iKw5yOrDAdSH7r/UIFLCVhLw==}
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  vite@6.4.1:
+    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@7.3.0:
     resolution: {integrity: sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==}
@@ -8941,6 +9218,14 @@ snapshots:
 
   '@chakra-ui/anatomy@2.3.6': {}
 
+  '@chakra-ui/hooks@2.4.5(react@18.3.1)':
+    dependencies:
+      '@chakra-ui/utils': 2.2.5(react@18.3.1)
+      '@zag-js/element-size': 0.31.1
+      copy-to-clipboard: 3.3.3
+      framesync: 6.1.2
+      react: 18.3.1
+
   '@chakra-ui/hooks@2.4.5(react@19.2.3)':
     dependencies:
       '@chakra-ui/utils': 2.2.5(react@19.2.3)
@@ -8948,6 +9233,26 @@ snapshots:
       copy-to-clipboard: 3.3.3
       framesync: 6.1.2
       react: 19.2.3
+
+  '@chakra-ui/react@2.10.9(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(framer-motion@11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@chakra-ui/hooks': 2.4.5(react@18.3.1)
+      '@chakra-ui/styled-system': 2.12.4(react@18.3.1)
+      '@chakra-ui/theme': 3.4.9(@chakra-ui/styled-system@2.12.4(react@18.3.1))(react@18.3.1)
+      '@chakra-ui/utils': 2.2.5(react@18.3.1)
+      '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)
+      '@popperjs/core': 2.11.8
+      '@zag-js/focus-visible': 0.31.1
+      aria-hidden: 1.2.6
+      framer-motion: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-fast-compare: 3.2.2
+      react-focus-lock: 2.13.7(@types/react@18.3.27)(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.27)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@chakra-ui/react@2.10.9(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(framer-motion@11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -8969,10 +9274,26 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@chakra-ui/styled-system@2.12.4(react@18.3.1)':
+    dependencies:
+      '@chakra-ui/utils': 2.2.5(react@18.3.1)
+      csstype: 3.2.3
+    transitivePeerDependencies:
+      - react
+
   '@chakra-ui/styled-system@2.12.4(react@19.2.3)':
     dependencies:
       '@chakra-ui/utils': 2.2.5(react@19.2.3)
       csstype: 3.2.3
+    transitivePeerDependencies:
+      - react
+
+  '@chakra-ui/theme-tools@2.2.9(@chakra-ui/styled-system@2.12.4(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@chakra-ui/anatomy': 2.3.6
+      '@chakra-ui/styled-system': 2.12.4(react@18.3.1)
+      '@chakra-ui/utils': 2.2.5(react@18.3.1)
+      color2k: 2.0.3
     transitivePeerDependencies:
       - react
 
@@ -8985,6 +9306,15 @@ snapshots:
     transitivePeerDependencies:
       - react
 
+  '@chakra-ui/theme@3.4.9(@chakra-ui/styled-system@2.12.4(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@chakra-ui/anatomy': 2.3.6
+      '@chakra-ui/styled-system': 2.12.4(react@18.3.1)
+      '@chakra-ui/theme-tools': 2.2.9(@chakra-ui/styled-system@2.12.4(react@18.3.1))(react@18.3.1)
+      '@chakra-ui/utils': 2.2.5(react@18.3.1)
+    transitivePeerDependencies:
+      - react
+
   '@chakra-ui/theme@3.4.9(@chakra-ui/styled-system@2.12.4(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@chakra-ui/anatomy': 2.3.6
@@ -8993,6 +9323,12 @@ snapshots:
       '@chakra-ui/utils': 2.2.5(react@19.2.3)
     transitivePeerDependencies:
       - react
+
+  '@chakra-ui/utils@2.2.5(react@18.3.1)':
+    dependencies:
+      '@types/lodash.mergewith': 4.6.9
+      lodash.mergewith: 4.6.2
+      react: 18.3.1
 
   '@chakra-ui/utils@2.2.5(react@19.2.3)':
     dependencies:
@@ -9101,6 +9437,22 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
+  '@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      hoist-non-react-statics: 3.3.2
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+    transitivePeerDependencies:
+      - supports-color
+
   '@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -9127,6 +9479,21 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@types/react@18.3.27)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/is-prop-valid': 1.4.0
+      '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+    transitivePeerDependencies:
+      - supports-color
+
   '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -9143,6 +9510,10 @@ snapshots:
       - supports-color
 
   '@emotion/unitless@0.10.0': {}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
 
   '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.3)':
     dependencies:
@@ -10760,6 +11131,8 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
   '@rollup/plugin-inject@5.0.5(rollup@4.55.1)':
@@ -12294,6 +12667,28 @@ snapshots:
       - csstype
       - solid-js
 
+  '@tanstack/react-router-devtools@1.157.14(@tanstack/react-router@1.144.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.144.0)(csstype@3.2.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/react-router': 1.144.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/router-devtools-core': 1.157.14(@tanstack/router-core@1.144.0)(csstype@3.2.3)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@tanstack/router-core': 1.144.0
+    transitivePeerDependencies:
+      - csstype
+
+  '@tanstack/react-router@1.144.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/history': 1.141.0
+      '@tanstack/react-store': 0.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/router-core': 1.144.0
+      isbot: 5.1.32
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tiny-invariant: 1.3.3
+      tiny-warning: 1.0.3
+
   '@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/history': 1.141.0
@@ -12304,6 +12699,13 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
+
+  '@tanstack/react-store@0.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/store': 0.8.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
 
   '@tanstack/react-store@0.8.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -12332,6 +12734,28 @@ snapshots:
     optionalDependencies:
       csstype: 3.2.3
 
+  '@tanstack/router-devtools-core@1.157.14(@tanstack/router-core@1.144.0)(csstype@3.2.3)':
+    dependencies:
+      '@tanstack/router-core': 1.144.0
+      clsx: 2.1.1
+      goober: 2.1.18(csstype@3.2.3)
+      tiny-invariant: 1.3.3
+    optionalDependencies:
+      csstype: 3.2.3
+
+  '@tanstack/router-devtools@1.157.14(@tanstack/react-router@1.144.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.144.0)(csstype@3.2.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/react-router': 1.144.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-router-devtools': 1.157.14(@tanstack/react-router@1.144.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.144.0)(csstype@3.2.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      goober: 2.1.18(csstype@3.2.3)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      csstype: 3.2.3
+    transitivePeerDependencies:
+      - '@tanstack/router-core'
+
   '@tanstack/router-generator@1.145.4':
     dependencies:
       '@tanstack/router-core': 1.144.0
@@ -12342,6 +12766,28 @@ snapshots:
       source-map: 0.7.6
       tsx: 4.21.0
       zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tanstack/router-plugin@1.145.4(@tanstack/react-router@1.144.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.4.1(@types/node@24.10.4)(jiti@2.6.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+      '@tanstack/router-core': 1.144.0
+      '@tanstack/router-generator': 1.145.4
+      '@tanstack/router-utils': 1.143.11
+      '@tanstack/virtual-file-routes': 1.145.4
+      babel-dead-code-elimination: 1.0.11
+      chokidar: 3.6.0
+      unplugin: 2.3.11
+      zod: 3.25.76
+    optionalDependencies:
+      '@tanstack/react-router': 1.144.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      vite: 6.4.1(@types/node@24.10.4)(jiti@2.6.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12383,7 +12829,7 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.145.4': {}
 
-  '@toju.network/sol@0.1.1(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@toju.network/sol@0.1.1(bufferutil@4.1.0)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -12787,6 +13233,30 @@ snapshots:
     dependencies:
       '@types/node': 24.10.4
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -12879,13 +13349,24 @@ snapshots:
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
+  '@types/prop-types@15.7.15': {}
+
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/react-dom@18.3.7(@types/react@18.3.27)':
+    dependencies:
+      '@types/react': 18.3.27
+
   '@types/react-dom@19.2.3(@types/react@19.2.7)':
     dependencies:
       '@types/react': 19.2.7
+
+  '@types/react@18.3.27':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
 
   '@types/react@19.2.7':
     dependencies:
@@ -13130,6 +13611,18 @@ snapshots:
       crypto-js: 4.2.0
       jose: 5.10.0
       neverthrow: 7.2.0
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@24.10.4)(jiti@2.6.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.1(@types/node@24.10.4)(jiti@2.6.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitejs/plugin-react@5.1.2(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -14766,6 +15259,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   dargs@7.0.0: {}
 
   data-urls@6.0.0:
@@ -14797,6 +15328,8 @@ snapshots:
       map-obj: 1.0.1
 
   decamelize@1.2.0: {}
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -14871,6 +15404,11 @@ snapshots:
       randombytes: 2.1.0
 
   dijkstrajs@1.0.3: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      csstype: 3.2.3
 
   domain-browser@4.22.0: {}
 
@@ -15370,6 +15908,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-equals@5.4.0: {}
+
   fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
@@ -15530,6 +16070,16 @@ snapshots:
   forwarded-parse@2.1.2: {}
 
   forwarded@0.2.0: {}
+
+  framer-motion@11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      motion-dom: 11.18.1
+      motion-utils: 11.18.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@emotion/is-prop-valid': 1.4.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   framer-motion@11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -15854,6 +16404,8 @@ snapshots:
       multiformats: 13.4.2
 
   interface-store@6.0.3: {}
+
+  internmap@2.0.3: {}
 
   invariant@2.2.4:
     dependencies:
@@ -17809,6 +18361,11 @@ snapshots:
       iconv-lite: 0.7.1
       unpipe: 1.0.0
 
+  react-clientside-effect@1.2.8(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      react: 18.3.1
+
   react-clientside-effect@1.2.8(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.28.4
@@ -17821,6 +18378,12 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:
@@ -17835,6 +18398,18 @@ snapshots:
       react: 19.2.3
 
   react-fast-compare@3.2.2: {}
+
+  react-focus-lock@2.13.7(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      focus-lock: 1.3.6
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-clientside-effect: 1.2.8(react@18.3.1)
+      use-callback-ref: 1.3.3(@types/react@18.3.27)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@18.3.27)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
 
   react-focus-lock@2.13.7(@types/react@19.2.7)(react@19.2.3):
     dependencies:
@@ -17925,7 +18500,17 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
+  react-refresh@0.17.0: {}
+
   react-refresh@0.18.0: {}
+
+  react-remove-scroll-bar@2.3.8(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-style-singleton: 2.2.3(@types/react@18.3.27)(react@18.3.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.27
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.7)(react@19.2.3):
     dependencies:
@@ -17934,6 +18519,17 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.7
+
+  react-remove-scroll@2.7.2(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.27)(react@18.3.1)
+      react-style-singleton: 2.2.3(@types/react@18.3.27)(react@18.3.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@18.3.27)(react@18.3.1)
+      use-sidecar: 1.1.3(@types/react@18.3.27)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.27
 
   react-remove-scroll@2.7.2(@types/react@19.2.7)(react@19.2.3):
     dependencies:
@@ -17946,6 +18542,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-style-singleton@2.2.3(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
   react-style-singleton@2.2.3(@types/react@19.2.7)(react@19.2.3):
     dependencies:
       get-nonce: 1.0.1
@@ -17953,6 +18565,19 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.7
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   react@19.2.3: {}
 
@@ -18019,6 +18644,23 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   redent@3.0.0:
     dependencies:
@@ -18206,6 +18848,10 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scheduler@0.27.0: {}
 
@@ -18623,6 +19269,12 @@ snapshots:
       url-parse: 1.5.10
       uuid: 10.0.0
 
+  swr@2.3.8(react@18.3.1):
+    dependencies:
+      dequal: 2.0.3
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
   swr@2.3.8(react@19.2.3):
     dependencies:
       dequal: 2.0.3
@@ -18885,6 +19537,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript@5.6.3: {}
+
   typescript@5.9.3: {}
 
   ua-is-frozen@0.1.2: {}
@@ -19009,12 +19663,27 @@ snapshots:
       node-addon-api: 8.5.0
       node-gyp-build: 4.8.4
 
+  use-callback-ref@1.3.3(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.27
+
   use-callback-ref@1.3.3(@types/react@19.2.7)(react@19.2.3):
     dependencies:
       react: 19.2.3
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.7
+
+  use-sidecar@1.1.3(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 18.3.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 18.3.27
 
   use-sidecar@1.1.3(@types/react@19.2.7)(react@19.2.3):
     dependencies:
@@ -19027,6 +19696,10 @@ snapshots:
   use-sync-external-store@1.2.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:
@@ -19087,6 +19760,23 @@ snapshots:
       uint8array-tools: 0.0.8
 
   vary@1.1.2: {}
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
@@ -19167,6 +19857,23 @@ snapshots:
       vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - rollup
+
+  vite@6.4.1(@types/node@24.10.4)(jiti@2.6.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.55.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.10.4
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      sass: 1.97.1
+      terser: 5.44.1
+      tsx: 4.21.0
+      yaml: 2.8.2
 
   vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:

--- a/server/drizzle/0005_add_usage_tables.sql
+++ b/server/drizzle/0005_add_usage_tables.sql
@@ -1,0 +1,34 @@
+CREATE TABLE "usage" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "usage_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"snapshot_date" date DEFAULT now() NOT NULL,
+	"total_bytes_stored" bigint NOT NULL,
+	"total_active_uploads" integer NOT NULL,
+	"storacha_reported_bytes" bigint,
+	"storacha_plan_limit" bigint,
+	"utilization_percentage" real,
+	"created_at" date DEFAULT now() NOT NULL
+);
+
+CREATE TABLE "usage_comparison" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "usage_comparison_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"comparison_date" date DEFAULT now() NOT NULL,
+	"our_calculated_bytes" bigint NOT NULL,
+	"storacha_reported_bytes" bigint NOT NULL,
+	"discrepancy_bytes" bigint NOT NULL,
+	"discrepancy_percentage" real NOT NULL,
+	"status" varchar(20) DEFAULT 'ok' NOT NULL,
+	"notes" text,
+	"created_at" date DEFAULT now() NOT NULL
+);
+
+CREATE TABLE "usage_alerts" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "usage_alerts_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"alert_type" varchar(50) NOT NULL,
+	"alert_level" varchar(20) NOT NULL,
+	"utilization_percentage" real,
+	"bytes_stored" bigint,
+	"plan_limit" bigint,
+	"message" text NOT NULL,
+	"resolved" date,
+	"created_at" date DEFAULT now() NOT NULL
+);

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -29,6 +29,20 @@
       "when": 1733947200000,
       "tag": "0003_rename_deposit_to_uploads",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1736121600000,
+      "tag": "0004_change_rate_to_real",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1737936000000,
+      "tag": "0005_add_usage_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/server/scripts/migrate.ts
+++ b/server/scripts/migrate.ts
@@ -1,7 +1,7 @@
 import { neon } from "@neondatabase/serverless";
 import { config } from "dotenv";
-import { drizzle } from "drizzle-orm/neon-http";
-import { migrate } from "drizzle-orm/neon-http/migrator";
+import { readdir, readFile } from "fs/promises";
+import path from "path";
 
 const env = process.argv[2] || "staging";
 const envFile = env === "production" ? ".env.prod" : ".env";
@@ -17,12 +17,80 @@ if (!process.env.DATABASE_URL) {
 }
 
 const sql = neon(process.env.DATABASE_URL);
-const db = drizzle(sql);
 
 const main = async () => {
   try {
-    await migrate(db, { migrationsFolder: "drizzle" });
-    console.log("Migration completed successfully");
+    // ensure __drizzle_migrations table exists
+    await sql`
+      CREATE TABLE IF NOT EXISTS __drizzle_migrations (
+        id SERIAL PRIMARY KEY,
+        hash TEXT NOT NULL,
+        created_at BIGINT
+      );
+    `;
+
+    // get already applied migrations
+    const appliedMigrations = await sql`
+      SELECT hash FROM __drizzle_migrations ORDER BY id;
+    `;
+    const appliedSet = new Set(appliedMigrations.map((m) => m.hash));
+
+    console.log(`Found ${appliedSet.size} previously applied migration(s)`);
+
+    // read migration files
+    const migrationsDir = path.join(process.cwd(), "drizzle");
+    const files = await readdir(migrationsDir);
+    const sqlFiles = files.filter((f) => f.endsWith(".sql")).sort();
+
+    console.log(`Found ${sqlFiles.length} migration file(s) on disk`);
+
+    let appliedCount = 0;
+
+    // apply pending migrations
+    for (const file of sqlFiles) {
+      const migrationName = file.replace(".sql", "");
+
+      if (appliedSet.has(migrationName)) {
+        console.log(`⏭️  Skipping ${migrationName} (already applied)`);
+        continue;
+      }
+
+      console.log(`🔄 Applying ${migrationName}...`);
+
+      const filePath = path.join(migrationsDir, file);
+      const migrationSQL = await readFile(filePath, "utf-8");
+
+      // split by statement breakpoint and execute each statement
+      const statements = migrationSQL
+        .split("--> statement-breakpoint")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+
+      for (const statement of statements) {
+        try {
+          await sql.unsafe(statement);
+        } catch (error) {
+          console.error(`❌ Error executing statement in ${migrationName}:`);
+          console.error(statement);
+          throw error;
+        }
+      }
+
+      // mark as applied
+      await sql`
+        INSERT INTO __drizzle_migrations (hash, created_at)
+        VALUES (${migrationName}, ${Date.now()});
+      `;
+
+      console.log(`✅ Applied ${migrationName}`);
+      appliedCount++;
+    }
+
+    if (appliedCount === 0) {
+      console.log("\n✨ No new migrations to apply");
+    } else {
+      console.log(`\n✅ Successfully applied ${appliedCount} migration(s)`);
+    }
   } catch (error) {
     console.error("Error during migration:", error);
     process.exit(1);

--- a/server/src/controllers/console.controller.ts
+++ b/server/src/controllers/console.controller.ts
@@ -1,53 +1,123 @@
 import { Request, Response } from "express";
-import { db } from "../db/db.js";
-import { configTable } from "../db/schema.js";
+import { UsageService } from "../services/usage/usage.service.js";
 import { logger } from "../utils/logger.js";
+import { initStorachaClient } from "../utils/storacha.js";
 
-//All the endpoints in this Particular controller are protected using Auth middleware
-
-export const updateRate = async (req: Request, res: Response) => {
+/**
+ * get usage history
+ */
+export const getUsageHistory = async (req: Request, res: Response) => {
   try {
-    const { rate } = req.body;
-    const result = await db
-      .update(configTable)
-      .set({
-        ratePerBytePerDay: rate,
-      })
-      .returning();
+    const days = parseInt(req.query.days as string) || 30;
+
+    const storachaClient = await initStorachaClient();
+    const usageService = new UsageService(storachaClient);
+    const history = await usageService.getUsageHistory(days);
+
     return res.status(200).json({
-      message: "Successfully updated the rate per file",
-      value: result[0].ratePerBytePerDay,
+      success: true,
+      data: history,
     });
-  } catch (err) {
-    logger.error("Error updating rate per file", {
-      error: err instanceof Error ? err.message : String(err),
+  } catch (error) {
+    logger.error("failed to get usage history", { error });
+    return res.status(500).json({
+      success: false,
+      error: "failed to fetch usage history",
     });
-    return res.status(500).json({ error: "Failed to update rate" });
   }
 };
 
 /**
- * Function to update the Minimum Duration
- * @returns
+ * get current usage
  */
-export const updateMinDuration = async (req: Request, res: Response) => {
+export const getCurrentUsage = async (req: Request, res: Response) => {
   try {
-    const { duration } = req.body; // duration should be kept in seconds easier to handle
-    const daysInSeconds = duration * 86400;
-    const result = await db
-      .update(configTable)
-      .set({
-        minDurationDays: daysInSeconds,
-      })
-      .returning();
+    const storachaClient = await initStorachaClient();
+    const usageService = new UsageService(storachaClient);
+
+    const [storachaUsage, internalUsage] = await Promise.all([
+      usageService.getStorachaUsage(),
+      usageService.calculateInternalUsage(),
+    ]);
+
+    const storachaBytes = storachaUsage.finalSize;
+    const planLimit = usageService["planLimitBytes"];
+    const utilization = planLimit > 0 ? (storachaBytes / planLimit) * 100 : 0;
+
     return res.status(200).json({
-      message: "Successfully updated the minimum Duration",
-      value: result[0].minDurationDays,
+      success: true,
+      data: {
+        storacha: {
+          totalBytes: storachaBytes,
+          planLimit,
+          utilizationPercentage: utilization,
+        },
+        internal: {
+          totalBytes: internalUsage.totalBytes,
+          activeUploads: internalUsage.activeUploads,
+        },
+        discrepancy: {
+          bytes: storachaBytes - internalUsage.totalBytes,
+          percentage:
+            internalUsage.totalBytes > 0
+              ? ((storachaBytes - internalUsage.totalBytes) /
+                  internalUsage.totalBytes) *
+                100
+              : 0,
+        },
+      },
     });
-  } catch (err) {
-    logger.error("Error updating minimum duration", {
-      error: err instanceof Error ? err.message : String(err),
+  } catch (error) {
+    logger.error("failed to get current usage", { error });
+    return res.status(500).json({
+      success: false,
+      error: "failed to fetch current usage",
     });
-    return res.status(500).json({ error: "Failed to update rate" });
+  }
+};
+
+/**
+ * get unresolved alerts
+ */
+export const getUnresolvedAlerts = async (req: Request, res: Response) => {
+  try {
+    const storachaClient = await initStorachaClient();
+    const usageService = new UsageService(storachaClient);
+    const alerts = await usageService.getUnresolvedAlerts();
+
+    return res.status(200).json({
+      success: true,
+      data: alerts,
+    });
+  } catch (error) {
+    logger.error("failed to get unresolved alerts", { error });
+    return res.status(500).json({
+      success: false,
+      error: "failed to fetch alerts",
+    });
+  }
+};
+
+/**
+ * resolve an alert
+ */
+export const resolveAlert = async (req: Request, res: Response) => {
+  try {
+    const alertId = parseInt(req.params.id);
+
+    const storachaClient = await initStorachaClient();
+    const usageService = new UsageService(storachaClient);
+    await usageService.resolveAlert(alertId);
+
+    return res.status(200).json({
+      success: true,
+      message: "alert resolved",
+    });
+  } catch (error) {
+    logger.error("failed to resolve alert", { error });
+    return res.status(500).json({
+      success: false,
+      error: "failed to resolve alert",
+    });
   }
 };

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -56,3 +56,48 @@ export const transaction = pgTable("transaction", {
   durationDays: integer("duration_days").notNull(),
   createdAt: date("created_at", { mode: "date" }).notNull().defaultNow(),
 });
+
+export const usage = pgTable("usage", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  snapshotDate: date("snapshot_date", { mode: "date" }).notNull().defaultNow(),
+  totalBytesStored: bigint("total_bytes_stored", { mode: "number" }).notNull(),
+  totalActiveUploads: integer("total_active_uploads").notNull(),
+  storachaReportedBytes: bigint("storacha_reported_bytes", { mode: "number" }),
+  storachaPlanLimit: bigint("storacha_plan_limit", { mode: "number" }),
+  utilizationPercentage: real("utilization_percentage"),
+  createdAt: date("created_at", { mode: "date" }).notNull().defaultNow(),
+});
+
+// compares whatver we've stored in our db with the data (capability.usage.report) we get from storacha
+export const usageComparison = pgTable("usage_comparison", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  comparisonDate: date("comparison_date", { mode: "date" })
+    .notNull()
+    .defaultNow(),
+  ourCalculatedBytes: bigint("our_calculated_bytes", {
+    mode: "number",
+  }).notNull(),
+  storachaReportedBytes: bigint("storacha_reported_bytes", {
+    mode: "number",
+  }).notNull(),
+  discrepancyBytes: bigint("discrepancy_bytes", { mode: "number" }).notNull(),
+  discrepancyPercentage: real("discrepancy_percentage").notNull(),
+  // 'ok' | 'warning' | 'critical'
+  status: varchar("status", { length: 20 }).notNull().default("ok"),
+  notes: text("notes"),
+  createdAt: date("created_at", { mode: "date" }).notNull().defaultNow(),
+});
+
+export const usageAlerts = pgTable("usage_alerts", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  // 'threshold_80' | 'threshold_90' | 'threshold_95' | 'comparison_discrepancy'
+  alertType: varchar("alert_type", { length: 50 }).notNull(),
+  // 'warning' | 'critical'
+  alertLevel: varchar("alert_level", { length: 20 }).notNull(),
+  utilizationPercentage: real("utilization_percentage"),
+  bytesStored: bigint("bytes_stored", { mode: "number" }),
+  planLimit: bigint("plan_limit", { mode: "number" }),
+  message: text("message").notNull(),
+  resolved: date("resolved", { mode: "date" }),
+  createdAt: date("created_at", { mode: "date" }).notNull().defaultNow(),
+});

--- a/server/src/routes/console.route.ts
+++ b/server/src/routes/console.route.ts
@@ -4,7 +4,9 @@ import { isMasterChief } from "../middlewares/auth.middleware.js";
 
 export const consoleRouter = express.Router();
 
-consoleRouter.use(isMasterChief); //middleware
+consoleRouter.use(isMasterChief);
 
-consoleRouter.post("/update-rate", consoleController.updateRate);
-consoleRouter.post("/update-min-duration", consoleController.updateMinDuration);
+consoleRouter.get("/usage/history", consoleController.getUsageHistory);
+consoleRouter.get("/usage/current", consoleController.getCurrentUsage);
+consoleRouter.get("/alerts", consoleController.getUnresolvedAlerts);
+consoleRouter.post("/alerts/:id/resolve", consoleController.resolveAlert);

--- a/server/src/routes/jobs.route.ts
+++ b/server/src/routes/jobs.route.ts
@@ -15,3 +15,15 @@ jobs.post(
   verifyQStashRequest,
   jobsController.deleteExpiredUploads,
 );
+
+jobs.post(
+  "/usage/snapshot",
+  verifyQStashRequest,
+  jobsController.dailyUsageSnapshot,
+);
+
+jobs.post(
+  "/usage/compare",
+  verifyQStashRequest,
+  jobsController.weeklyUsageComparison,
+);

--- a/server/src/services/usage/usage.service.ts
+++ b/server/src/services/usage/usage.service.ts
@@ -1,0 +1,329 @@
+import { Client as StorachaClient } from "@storacha/client";
+import { eq, sql } from "drizzle-orm";
+import { db } from "../../db/db.js";
+import {
+  uploads,
+  usage,
+  usageAlerts,
+  usageComparison,
+} from "../../db/schema.js";
+import { logger } from "../../utils/logger.js";
+import { Resend } from "resend";
+
+const { CONSOLE_URL, EMAIL_FROM, EMAIL_TO, WATCHMAN, RESEND_API_KEY } =
+  process.env!;
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+interface UsageReport {
+  finalSize: number;
+  initialSize: number;
+}
+
+export class UsageService {
+  private client: StorachaClient;
+  private planLimitBytes: number;
+
+  constructor(client: StorachaClient, planLimitBytes: number = 5_000_000_000) {
+    this.client = client;
+    this.planLimitBytes = planLimitBytes; // default 5GB for free plan for now, so we can test
+  }
+
+  /**
+   * fetch current usage from storacha using capability.usage.report
+   */
+  async getStorachaUsage(
+    from: Date = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    to: Date = new Date(),
+  ): Promise<UsageReport> {
+    try {
+      const currentSpace = this.client.currentSpace();
+      if (!currentSpace) throw new Error("no storacha space available");
+
+      const spaceDid = currentSpace.did();
+      const report = await this.client.capability.usage.report(spaceDid, {
+        from,
+        to,
+      });
+
+      // report is Record<DID, UsageData>, get the first/only entry
+      const usageData = Object.values(report)[0];
+
+      if (!usageData) {
+        throw new Error("no usage data returned from storacha");
+      }
+
+      return {
+        finalSize: usageData.size.final,
+        initialSize: usageData.size.initial,
+      };
+    } catch (error) {
+      logger.error("failed to fetch storacha usage report", { error });
+      throw new Error("failed to fetch storacha usage");
+    }
+  }
+
+  /**
+   * calculate our internal usage sum from the uploads table
+   */
+  async calculateInternalUsage(): Promise<{
+    totalBytes: number;
+    activeUploads: number;
+  }> {
+    const result = await db
+      .select({
+        totalBytes: sql<number>`COALESCE(SUM(${uploads.fileSize}), 0)`,
+        activeUploads: sql<number>`COUNT(*)`,
+      })
+      .from(uploads)
+      .where(eq(uploads.deletionStatus, "active"));
+
+    return {
+      totalBytes: Number(result[0]?.totalBytes || 0),
+      activeUploads: Number(result[0]?.activeUploads || 0),
+    };
+  }
+
+  /**
+   * create daily snapshot of usage
+   */
+  async createDailySnapshot(): Promise<void> {
+    try {
+      const [storachaUsage, internalUsage] = await Promise.all([
+        this.getStorachaUsage(),
+        this.calculateInternalUsage(),
+      ]);
+
+      const storachaBytes = storachaUsage.finalSize;
+      const utilization =
+        this.planLimitBytes > 0
+          ? (storachaBytes / this.planLimitBytes) * 100
+          : 0;
+
+      await db.insert(usage).values({
+        totalBytesStored: internalUsage.totalBytes,
+        totalActiveUploads: internalUsage.activeUploads,
+        storachaReportedBytes: storachaBytes,
+        storachaPlanLimit: this.planLimitBytes,
+        utilizationPercentage: utilization,
+      });
+
+      logger.info("daily usage snapshot created", {
+        totalBytes: internalUsage.totalBytes,
+        activeUploads: internalUsage.activeUploads,
+        storachaReportedBytes: storachaBytes,
+        utilization: `${utilization.toFixed(2)}%`,
+      });
+
+      await this.checkThresholds(
+        utilization,
+        storachaBytes,
+        this.planLimitBytes,
+      );
+    } catch (error) {
+      logger.error("failed to create daily snapshot", { error });
+      throw error;
+    }
+  }
+
+  /**
+   * weekly comparison between our data and the capability report
+   */
+  async compareUsage(): Promise<void> {
+    try {
+      const [storachaUsage, internalUsage] = await Promise.all([
+        this.getStorachaUsage(),
+        this.calculateInternalUsage(),
+      ]);
+
+      const storachaBytes = storachaUsage.finalSize;
+      const discrepancy = storachaBytes - internalUsage.totalBytes;
+      const discrepancyPercentage =
+        internalUsage.totalBytes > 0
+          ? (Math.abs(discrepancy) / internalUsage.totalBytes) * 100
+          : 0;
+
+      const status =
+        discrepancyPercentage > 10
+          ? "critical"
+          : discrepancyPercentage > 5
+            ? "warning"
+            : "ok";
+
+      await db.insert(usageComparison).values({
+        ourCalculatedBytes: internalUsage.totalBytes,
+        storachaReportedBytes: storachaBytes,
+        discrepancyBytes: discrepancy,
+        discrepancyPercentage,
+        status,
+        notes:
+          status !== "ok"
+            ? `discrepancy of ${(discrepancy / 1e9).toFixed(2)} GB (${discrepancyPercentage.toFixed(2)}%)` // 1e9 = 1GB in bytes
+            : null,
+      });
+
+      logger.info("usage comparison completed", {
+        ourBytes: internalUsage.totalBytes,
+        storachaBytes,
+        discrepancy,
+        status,
+      });
+
+      if (status !== "ok") {
+        await this.createAlert({
+          alertType: "comparison_discrepancy",
+          alertLevel: status === "critical" ? "critical" : "warning",
+          message: `usage comparison shows ${discrepancyPercentage.toFixed(2)}% discrepancy (${(Math.abs(discrepancy) / 1e9).toFixed(2)} GB difference)`,
+        });
+      }
+    } catch (error) {
+      logger.error("failed to compare usage", { error });
+      throw error;
+    }
+  }
+
+  /**
+   * check utilization thresholds and create alerts
+   */
+  private async checkThresholds(
+    utilization: number,
+    bytesStored: number,
+    planLimit: number,
+  ): Promise<void> {
+    const thresholds = [
+      { level: 80, type: "threshold_80", alertLevel: "warning" as const },
+      { level: 90, type: "threshold_90", alertLevel: "warning" as const },
+      { level: 95, type: "threshold_95", alertLevel: "critical" as const },
+    ];
+
+    for (const threshold of thresholds) {
+      if (utilization >= threshold.level) {
+        // check if alert already exists and is unresolved
+        const existingAlert = await db
+          .select()
+          .from(usageAlerts)
+          .where(
+            sql`${usageAlerts.alertType} = ${threshold.type} AND ${usageAlerts.resolved} IS NULL`,
+          )
+          .limit(1);
+
+        if (existingAlert.length === 0) {
+          await this.createAlert({
+            alertType: threshold.type,
+            alertLevel: threshold.alertLevel,
+            utilizationPercentage: utilization,
+            bytesStored,
+            planLimit,
+            message: `usage at ${utilization.toFixed(2)}% (${(bytesStored / 1e9).toFixed(2)} GB / ${(planLimit / 1e9).toFixed(2)} GB)`,
+          });
+
+          logger.warn(`usage threshold alert: ${threshold.level}%`, {
+            utilization: `${utilization.toFixed(2)}%`,
+            bytesStored,
+            planLimit,
+          });
+        }
+      }
+    }
+  }
+
+  /**
+   * create usage alert and send email
+   */
+  private async createAlert(alert: {
+    alertType: string;
+    alertLevel: "warning" | "critical";
+    utilizationPercentage?: number;
+    bytesStored?: number;
+    planLimit?: number;
+    message: string;
+  }): Promise<void> {
+    await db.insert(usageAlerts).values(alert);
+    logger.info("usage alert created", alert);
+
+    try {
+      await resend.emails.send({
+        from: EMAIL_FROM as string,
+        to: WATCHMAN as string | string[],
+        subject: `🚨 [${alert.alertLevel.toUpperCase()}] storage alert - ${alert.alertType.replace(/_/g, " ")}`,
+        html: `
+          <div style="font-family: Inter, sans-serif; max-width: 600px; background: #080808; color: #fff; padding: 32px; border-radius: 12px;">
+            <h2 style="color: ${alert.alertLevel === "critical" ? "#ef4444" : "#f59e0b"}; margin-bottom: 16px;">
+              ${alert.alertLevel === "critical" ? "🔴" : "⚠️"} storage ${alert.alertLevel} alert
+            </h2>
+            <p style="color: #949495; margin-bottom: 24px; font-size: 16px;">${alert.message}</p>
+            
+            ${
+              alert.utilizationPercentage
+                ? `
+              <div style="background: #100f0f; padding: 16px; border-radius: 8px; margin-bottom: 16px; border: 1px solid #141414;">
+                <p style="color: #949495; font-size: 14px; margin-bottom: 8px;">utilization</p>
+                <p style="font-size: 32px; font-weight: 600; color: ${alert.alertLevel === "critical" ? "#ef4444" : "#f59e0b"}; margin: 0;">
+                  ${alert.utilizationPercentage.toFixed(2)}%
+                </p>
+                ${
+                  alert.bytesStored && alert.planLimit
+                    ? `
+                  <p style="color: #949495; font-size: 14px; margin-top: 8px;">
+                    ${(alert.bytesStored / 1e9).toFixed(2)} GB / ${(alert.planLimit / 1e9).toFixed(2)} GB
+                  </p>
+                `
+                    : ""
+                }
+              </div>
+            `
+                : ""
+            }
+            
+            <p style="color: #949495; font-size: 12px; margin-top: 24px; padding-top: 24px; border-top: 1px solid #141414;">
+              alert type: ${alert.alertType}<br/>
+              created: ${new Date().toISOString()}
+            </p>
+          </div>
+        `,
+        text: `${alert.alertLevel.toUpperCase()} STORAGE ALERT\n\n${alert.message}\n\nAlert Type: ${alert.alertType}`,
+      });
+
+      logger.info("alert email sent", {
+        to: WATCHMAN,
+        alertType: alert.alertType,
+      });
+    } catch (error) {
+      logger.error("failed to send alert email", { error });
+      // don't throw - alert is already in DB
+    }
+  }
+
+  /**
+   * get recent usage history
+   */
+  async getUsageHistory(days: number = 30) {
+    return await db
+      .select()
+      .from(usage)
+      .orderBy(sql`${usage.snapshotDate} DESC`)
+      .limit(days);
+  }
+
+  /**
+   * get unresolved alerts
+   */
+  async getUnresolvedAlerts() {
+    return await db
+      .select()
+      .from(usageAlerts)
+      .where(sql`${usageAlerts.resolved} IS NULL`)
+      .orderBy(sql`${usageAlerts.createdAt} DESC`);
+  }
+
+  /**
+   * resolve an alert
+   */
+  async resolveAlert(alertId: number): Promise<void> {
+    await db
+      .update(usageAlerts)
+      .set({ resolved: new Date() })
+      .where(eq(usageAlerts.id, alertId));
+
+    logger.info("usage alert resolved", { alertId });
+  }
+}


### PR DESCRIPTION
added the usage monitoring with `capability.usage.report` for our storage threshold warnings (80%, 90%, 95%) and weekly discrepancy detection.

i've also fixed the drizzle migration script. the previous one was too basic as it did not cover situations when previous migrations have already been applied and it tries to run it from scratch again. now it tracks applied migrations.

closes #124