### PR TITLE
chore(docs): cleanup README and include MIT license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,235 @@
+# Contributing to toju (keep)
+
+Thanks for your interest in contributing to Toju! This guide will help you get set up for local development.
+
+## Monorepo Structure
+
+```
+ui/               # React frontend (Vite + Chakra UI)
+solana-programs/  # Solana payment contract (Anchor framework)
+server/           # Node.js backend (Express + Drizzle)
+sdk/              # TypeScript SDK (@toju.network/sol)
+docs/             # Mintlify documentation
+```
+
+## Prerequisites
+
+- [Rust & Cargo](https://www.rust-lang.org/tools/install)
+- [Solana CLI](https://solana.com/docs/intro/installation) - **Use the Anza installer:**
+  ```bash
+  sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
+  ```
+- [Anchor Framework](https://www.anchor-lang.com/docs/installation)
+- [Node.js >= 20](https://nodejs.org/en/) and [pnpm](https://pnpm.io/installation)
+- [Storacha CLI](https://storacha.network) - `npm install -g @storacha/cli`
+
+## Getting Started
+
+### 1. Clone & Install Dependencies
+
+```bash
+git clone https://github.com/seetadev/storacha-solana-sdk.git
+cd storacha-solana-sdk
+pnpm install
+```
+
+### 2. Installing Dependencies in Workspace Packages
+
+This is a pnpm workspace monorepo. Use the `-F` (or `--filter`) flag to install in specific packages:
+
+```bash
+pnpm add <package-name> -F server    # server workspace
+pnpm add <package-name> -F ui        # UI workspace
+pnpm add <package-name> -F sdk       # SDK workspace
+pnpm add -D <package-name> -F server # dev dependencies
+```
+
+**Don't install at root** unless it's a shared dev tool (like TypeScript or ESLint).
+
+## Solana Local Development
+
+### 1. Start Local Validator
+
+```bash
+cd solana-programs
+
+# macOS: remove old ledgers and prevent resource fork issues
+rm -rf test-ledger
+export COPYFILE_DISABLE=true
+
+solana-test-validator
+```
+
+### 2. Build & Deploy the Program
+
+In a new terminal:
+
+```bash
+cd solana-programs
+anchor build
+anchor deploy
+```
+
+### 3. Airdrop SOL
+
+```bash
+solana airdrop 2
+```
+
+If rate-limited, retry after a few seconds. Max is 5 SOL per request.
+
+## Server Setup
+
+### Database Setup
+
+We use [Neon](https://neon.tech) for PostgreSQL. Each contributor should set up their own instance.
+
+1. Create a free account at [neon.tech](https://neon.tech)
+2. Create a new project (e.g., `toju-local-dev`)
+3. Copy your connection string from the dashboard
+
+### Environment Variables
+
+```bash
+cd server
+cp .env.example .env
+./scripts/generate-admin-key.sh
+```
+
+Fill in your `.env`:
+- `DATABASE_URL` - Neon connection string
+- `RESEND_API_KEY` - Get from [resend.com](https://resend.com)
+- `BTRSTACK_SOURCE_TOKEN` / `BTRSTACK_SOURCE_ID` - For Betterstack logging
+- `ADMIN_KEYPAIR` - Output from generate-admin-key.sh
+- `STORACHA_KEY` / `STORACHA_PROOF` - See Storacha setup below
+
+### Storacha Setup
+
+Generate `STORACHA_KEY` and `STORACHA_PROOF`:
+
+```bash
+# 1. Login to Storacha
+storacha login
+
+# 2. Create a space
+storacha space create my-space-name
+
+# 3. Generate server agent key
+storacha key create
+# Output: did:key:z6Mk... (server agent DID)
+# Also outputs private key - save as STORACHA_KEY
+
+# 4. Select your space
+storacha space use did:key:z6Mk...  # your space DID
+
+# 5. Create delegation with all capabilities
+storacha delegation create did:key:z6Mk... \
+  --can 'space/*' \
+  --can 'blob/*' \
+  --can 'index/*' \
+  --can 'store/*' \
+  --can 'upload/*' \
+  --can 'access/*' \
+  --can 'filecoin/*' \
+  --can 'usage/*' \
+  --base64
+# Output: base64 string - save as STORACHA_PROOF
+```
+
+**Important:** All capabilities above are required:
+- `store/*` and `upload/*` - file uploads
+- `upload/*` - deleting expired files (`upload/remove`)
+- `usage/*` - usage monitoring and reporting
+
+**Finding your server agent DID from an existing key:**
+```bash
+cd server
+node -e "import('@storacha/client/principal/ed25519').then(({Signer}) => console.log(Signer.parse('YOUR_STORACHA_KEY_VALUE').did()))"
+```
+
+### Database Migrations
+
+```bash
+cd server
+
+# Generate migration files
+pnpm db:generate
+
+# Apply migrations
+pnpm db:migrate
+
+# Seed config table
+pnpm db:seed
+```
+
+### Run the Server
+
+```bash
+cd server
+pnpm dev
+```
+
+## SDK Development
+
+### Build the SDK
+
+```bash
+cd sdk
+pnpm build
+```
+
+### Testing SDK Changes Locally
+
+The UI is already configured to use the workspace SDK. Changes to the SDK are reflected after rebuilding:
+
+```bash
+cd sdk
+pnpm build
+```
+
+The `ui/package.json` uses `"@toju.network/sol": "workspace:*"` which symlinks to the local SDK.
+
+## UI Development
+
+```bash
+cd ui
+pnpm dev
+```
+
+## Documentation
+
+We use [Mintlify](https://mintlify.com) for docs.
+
+### Run docs locally
+
+```bash
+pnpm docs:dev
+```
+
+Starts at `http://localhost:3000` with hot-reload.
+
+### Adding pages
+
+1. Create `.mdx` file in `docs/` (e.g., `docs/sdk/new-feature.mdx`)
+2. Add frontmatter:
+   ```mdx
+   ---
+   title: 'Your Page Title'
+   description: 'Brief description'
+   ---
+   ```
+3. Add to `docs/mint.json` navigation array
+
+## Notes
+
+- **Program IDL:** Generated at `target/idl/solana_programs.json` after build
+- **Program ID:** Pre-generated at `solana-programs/target/deploy/solana_programs-keypair.json`
+- **macOS:** Always set `export COPYFILE_DISABLE=true` before `solana-test-validator`
+- **Anchor versioning:** Ensure `anchor-lang` in Cargo.toml matches your Anchor CLI version
+
+## Testing the App
+
+1. Install [Phantom wallet](https://phantom.app/) browser extension
+2. Enable testnet in Settings > Developer Settings
+3. Get test SOL from [Solana Faucet](https://faucet.solana.com/)
+4. Try the app at [toju.network](https://toju.network)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 toju
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/CONTRIBUTING.md
+++ b/sdk/CONTRIBUTING.md
@@ -1,19 +1,64 @@
-Fork this repo, and cd into the `sdk` directory.
+# Contributing to @toju.network/sol SDK
 
-Use the command below to get a copy of the environment variables
+## Setup
 
-```shell
-cp .env.example .env
+1. Clone the repo and install dependencies from the root:
+
+```bash
+git clone https://github.com/seetadev/storacha-solana-sdk.git
+cd storacha-solana-sdk
+pnpm install
 ```
 
-Add your changes and ensure you test them locally by running `pnpm build` then pack it with `pnpm pack`
+2. Navigate to the SDK directory:
 
-When that's done, add the tarball as a link in your `package.json` like so:
-
-```json
-  "storacha-sol": "file:../sdk/storacha-sol-0.0.1.tgz"
+```bash
+cd sdk
 ```
 
-Or better still, test the changes in the `frontend` directory.
+## Development
 
-When you're set, open a PR, and expect a review.
+### Building
+
+```bash
+pnpm build
+```
+
+### Testing Changes Locally
+
+The monorepo uses pnpm workspaces. The UI (`ui/`) is configured to use `"@toju.network/sol": "workspace:*"`, which symlinks to the local SDK.
+
+To test your changes:
+
+1. Build the SDK:
+   ```bash
+   cd sdk
+   pnpm build
+   ```
+
+2. Run the UI:
+   ```bash
+   cd ../ui
+   pnpm dev
+   ```
+
+Your SDK changes will be reflected immediately after rebuilding.
+
+### Code Style
+
+- Use TypeScript
+- Follow existing patterns in the codebase
+- Keep functions focused and well-documented
+
+## Submitting Changes
+
+1. Fork the repo
+2. Create a feature branch
+3. Make your changes
+4. Run `pnpm build` to ensure it compiles
+5. Test your changes using the UI
+6. Open a PR with a clear description
+
+## Questions?
+
+Open an issue or reach out on [GitHub Discussions](https://github.com/seetadev/Storacha-Solana-SDK/discussions).

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -36,7 +36,7 @@
     "blockchain"
   ],
   "author": "toju.network",
-  "license": "ISC",
+  "license": "MIT",
   "description": "Decentralized storage SDK for Solana via Storacha - pay with SOL, store on IPFS",
   "packageManager": "pnpm@10.11.0",
   "dependencies": {


### PR DESCRIPTION
the previous README was too conflated with information that may be easy for people to miss.

having a separate contributing.md file makes it easier to onboard people easily, while the main readme briefly explains what the sdk is about.

i've also included the MIT license that has been missing from the get-go