### PR TITLE
fix: stop lowercasing Solana public keys in deposit storage

### DIFF
--- a/server/src/controllers/upload.controller.ts
+++ b/server/src/controllers/upload.controller.ts
@@ -234,7 +234,7 @@ export const deposit = async (req: Request, res: Response) => {
     const depositMetadata = {
       depositAmount: amountInLamports,
       durationDays: duration_days,
-      depositKey: publicKey.toLowerCase(),
+      depositKey: publicKey,
       userEmail: userEmail || null,
       fileName: fileArray.length === 1 ? fileArray[0].originalname : null,
       fileType: fileArray.length === 1 ? fileArray[0].mimetype : 'directory',

--- a/server/src/db/uploads-table.ts
+++ b/server/src/db/uploads-table.ts
@@ -29,7 +29,7 @@ export const getUserHistory = async (
   ctx?: PaginationContext,
 ) => {
   try {
-    const userAddress = wallet.toLowerCase()
+    const userAddress = wallet
     const offset = (page - 1) * limit
 
     const [{ count }] = await db


### PR DESCRIPTION
## Problem
Solana public keys are base58-encoded and case-sensitive. We were storing 
depositKey with publicKey.toLowerCase(), corrupting the address and breaking 
lookups when users query with the canonical public key from their wallet.

## Solution
- Remove .toLowerCase() when storing depositKey in upload.controller
- Remove .toLowerCase() when querying by wallet in uploads-table