### PR TITLE
fix server deployment failure

### DIFF
--- a/packages/fil/package.json
+++ b/packages/fil/package.json
@@ -6,6 +6,9 @@
     "ethers": "^6.16.0"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "knip": "^5.72.0",
+    "standard-version": "^9.5.0",
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
this was because the pnpm-lock file in the `fil` module was missing the required dependencies