### PR TITLE
feat: Initialize Filecoin ethers provider setup

### DIFF
--- a/packages/fil/src/client.ts
+++ b/packages/fil/src/client.ts
@@ -1,9 +1,52 @@
+import { JsonRpcProvider } from 'ethers'
+import { FILECOIN_RPC } from './constants'
+
+export enum Environment {
+  mainnet = 'mainnet',
+  calibration = 'calibration',
+}
+
+export function getRpcUrl(env: Environment): string {
+  switch (env) {
+    case Environment.mainnet:
+      return FILECOIN_RPC.mainnet
+    case Environment.calibration:
+      return FILECOIN_RPC.calibration
+    default:
+      throw new Error(`Unsupported environment: ${env}`)
+  }
+}
+
+export interface ClientOptions {
+  /** Filecoin RPC environment */
+  environment: Environment
+  /** Optional custom RPC override */
+  rpcUrl?: string
+  /** Optional backend API endpoint */
+  endpoint?: string
+}
+
+/**
+ * Filecoin Storage Client
+ */
 export class Client {
-  constructor() {
-    // TODO: Initialize ethers provider
+  private rpcUrl: string
+  public provider: JsonRpcProvider
+
+  constructor(options: ClientOptions) {
+    this.rpcUrl = options.rpcUrl || getRpcUrl(options.environment)
+    this.provider = new JsonRpcProvider(this.rpcUrl)
   }
 
+  /**
+   * Create deposit transaction (FIL / USDFC)
+   */
   async createDeposit() {
-    throw new Error('Not implemented') // this should be implemented in teh next set of PRs
+    console.log('Creating Filecoin deposit using RPC:', this.rpcUrl)
+
+    const network = await this.provider.getNetwork()
+    console.log('Connected to chain:', network.chainId)
+
+    throw new Error('Not implemented')
   }
 }


### PR DESCRIPTION
This PR closes #169 and adds initial `ethers.js` provider setup for the Filecoin SDK.

* Introduces `Environment` enum (`mainnet`, `calibration`)
* Initializes `JsonRpcProvider` in the `Client` constructor
* Aligns structure with existing SOL SDK pattern
* Leaves deposit logic intentionally unimplemented (WIP)

This establishes mainnet + calibration connectivity and prepares the SDK for upcoming USDFC/FIL deposit implementation.
