### PR TITLE
fix: use the plan limit from an account instead of a default 5GiB

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ pnpm add <package-name> -F server         # server workspace
 pnpm add <package-name> -F ui             # UI workspace
 pnpm add <package-name> -F @toju.network/sol  # Solana SDK
 pnpm add <package-name> -F @toju.network/fil  # Filecoin SDK
-pnpm add -D <package-name> -F server      # dev dependencies
+pnpm add -D <package-name> -F <workspace>      # dev dependencies
 ```
 
 **Don't install at root** unless it's a shared dev tool (like TypeScript or ESLint).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^1.98.4
         version: 1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@storacha/client':
-        specifier: ^1.6.0
-        version: 1.8.26(encoding@0.1.13)
+        specifier: ^2.0.4
+        version: 2.0.4(encoding@0.1.13)
       '@types/bn.js':
         specifier: ^5.2.0
         version: 5.2.0
@@ -3001,14 +3001,11 @@ packages:
     engines: {node: '>=16.15'}
     hasBin: true
 
-  '@storacha/capabilities@1.12.0':
-    resolution: {integrity: sha512-d4YTllc9eoe/aZU8OCMszJgSnNHsXWpUNHRVlU+u3BDVCTqN6SZHEqR7HhYpr9IDC+pOz/f6nOj5iICiH3t77g==}
-
   '@storacha/capabilities@2.2.0':
     resolution: {integrity: sha512-xXXdwNkwWqMliR43PO+D58NqNnJ6b8bGmJ3NuFxkr0AjdQTuMjHK0woLRX+n7DKhDWDyKA2NOy3pdXlrXWTuQQ==}
 
-  '@storacha/client@1.8.26':
-    resolution: {integrity: sha512-rH7kRqlhoOMsMU6C87fBGBBDodusGDNhPON+4lpS+IXpzreCT/RCxMknuBUr4tqx8oQ9N0vxylcTxOGkBo/Zjg==}
+  '@storacha/client@2.0.4':
+    resolution: {integrity: sha512-VxGvFlWsvnuOZZEL+pcuI6DrLlCwRp5CSJU35WbNEHjGZGkjBHZmx0WONwqoHE1PV32oecy+o55vtq9LC8hnPg==}
     engines: {node: '>=18'}
 
   '@storacha/did-mailto@1.0.2':
@@ -11326,7 +11323,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -12574,16 +12571,6 @@ snapshots:
       sade: 1.8.1
       uint8arrays: 5.1.0
 
-  '@storacha/capabilities@1.12.0':
-    dependencies:
-      '@ucanto/core': 10.4.6
-      '@ucanto/interface': 11.0.1
-      '@ucanto/principal': 9.0.3
-      '@ucanto/transport': 9.2.1
-      '@ucanto/validator': 10.0.1
-      '@web3-storage/data-segment': 5.3.0
-      multiformats: 13.4.2
-
   '@storacha/capabilities@2.2.0':
     dependencies:
       '@ucanto/core': 10.4.6
@@ -12594,12 +12581,12 @@ snapshots:
       '@web3-storage/data-segment': 5.3.0
       multiformats: 13.4.2
 
-  '@storacha/client@1.8.26(encoding@0.1.13)':
+  '@storacha/client@2.0.4(encoding@0.1.13)':
     dependencies:
       '@ipld/dag-ucan': 3.4.5
       '@storacha/access': 1.6.7
       '@storacha/blob-index': 1.2.7
-      '@storacha/capabilities': 1.12.0
+      '@storacha/capabilities': 2.2.0
       '@storacha/did-mailto': 1.0.2
       '@storacha/filecoin-client': 1.0.18
       '@storacha/upload-client': 1.3.9(encoding@0.1.13)
@@ -18231,10 +18218,10 @@ snapshots:
   ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
       '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
+      '@scure/bip39': 1.6.0
       abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -42,7 +42,7 @@
     "@sentry/node": "^10.33.0",
     "@sentry/profiling-node": "^10.33.0",
     "@solana/web3.js": "^1.98.4",
-    "@storacha/client": "^1.6.0",
+    "@storacha/client": "^2.0.4",
     "@types/bn.js": "^5.2.0",
     "@ucanto/core": "^10.4.0",
     "@upstash/qstash": "^2.8.4",

--- a/server/src/controllers/console.controller.ts
+++ b/server/src/controllers/console.controller.ts
@@ -13,6 +13,7 @@ export const getUsageHistory = async (req: Request, res: Response) => {
 
     const storachaClient = await initStorachaClient()
     const usageService = new UsageService(storachaClient)
+    await usageService.initialize()
     const history = await usageService.getUsageHistory(days)
 
     return res.status(200).json({
@@ -35,6 +36,7 @@ export const getCurrentUsage = async (_req: Request, res: Response) => {
   try {
     const storachaClient = await initStorachaClient()
     const usageService = new UsageService(storachaClient)
+    await usageService.initialize()
 
     const [storachaUsage, internalUsage] = await Promise.all([
       usageService.getStorachaUsage(),
@@ -84,6 +86,7 @@ export const getUnresolvedAlerts = async (_req: Request, res: Response) => {
   try {
     const storachaClient = await initStorachaClient()
     const usageService = new UsageService(storachaClient)
+    await usageService.initialize()
     const alerts = await usageService.getUnresolvedAlerts()
 
     return res.status(200).json({
@@ -111,6 +114,7 @@ export const resolveAlert = async (req: Request, res: Response) => {
 
     const storachaClient = await initStorachaClient()
     const usageService = new UsageService(storachaClient)
+    await usageService.initialize()
     await usageService.resolveAlert(alertId)
 
     return res.status(200).json({

--- a/server/src/controllers/jobs.controller.ts
+++ b/server/src/controllers/jobs.controller.ts
@@ -177,6 +177,7 @@ export const dailyUsageSnapshot = async (_req: Request, res: Response) => {
 
     const storachaClient = await initStorachaClient()
     const usageService = new UsageService(storachaClient)
+    await usageService.initialize()
 
     await usageService.createDailySnapshot()
 
@@ -203,6 +204,7 @@ export const weeklyUsageComparison = async (_req: Request, res: Response) => {
 
     const storachaClient = await initStorachaClient()
     const usageService = new UsageService(storachaClient)
+    await usageService.initialize()
 
     await usageService.compareUsage()
 


### PR DESCRIPTION
the usage service previously defaults to a 5GiB plan limit which is the free storage limit plan on storacha.

but everywhere in our background jobs controller for the usage report we'd still have to explicitly pass the plan limit or just hardcode the limit when we upgrade to a large storage capacity, which can be quite the hassle &mdash; having to edit the code everytime we upgrade.

after a chat with travis, i found out that the `PlanGetSuccess` response from the `plan/get` capability already includes an optional `limit` prop proposed in the [spec: #607](https://github.com/storacha/specs/pull/150)