### PR TITLE
fix: fixed an issue with halfway upload flow using USDFC where it just stops at verify-payment.

### DIFF
--- a/packages/fil/src/types.ts
+++ b/packages/fil/src/types.ts
@@ -74,6 +74,8 @@ export interface DepositResponse {
   fileCount: number
   /** Total size of all files in bytes */
   totalSize: number
+  /** result of a successful upload */
+  object: UploadResult
   /** Array of file information */
   files: Array<{
     name: string

--- a/server/src/controllers/upload.controller.ts
+++ b/server/src/controllers/upload.controller.ts
@@ -237,7 +237,7 @@ export const deposit = async (req: Request, res: Response) => {
   }
 }
 
-/** the return type  */
+/** the return type for fileBuilder  */
 type FileMeta = {
   totalSize: number
   fileArray: Express.Multer.File[]
@@ -480,6 +480,7 @@ export const confirmUpload = async (req: Request, res: Response) => {
         })
 
         return res.status(200).json({
+          verified: true,
           message: 'Transaction hash updated successfully',
           deposit: updated[0],
         })
@@ -642,6 +643,7 @@ export const verifyUsdFcPayment = async (req: Request, res: Response) => {
     })
 
     return res.status(200).json({
+      verified: true,
       message: 'USDFC payment verified and upload confirmed successfully',
       deposit: inserted[0],
     })


### PR DESCRIPTION
while i tried the fil package out, i noticed the flow just stops at `/verify-payment` partly because i had not included the calls to the `/upload/file(s)` endpoints, and because i failed to return the `verified` property in the response.

this should address it.