### PR TITLE
fix: remove useFileDetails dependency on wallet address in renewal page

### DIFF
--- a/server/drizzle/0008_backfill_payment_chain.sql
+++ b/server/drizzle/0008_backfill_payment_chain.sql
@@ -1,0 +1,2 @@
+UPDATE "uploads" SET "payment_chain" = 'sol', "payment_token" = 'SOL' WHERE "payment_chain" IS NULL;
+UPDATE "transactions" SET "payment_chain" = 'sol', "payment_token" = 'SOL' WHERE "payment_chain" IS NULL;

--- a/server/drizzle/meta/_journal.json
+++ b/server/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1739232000000,
       "tag": "0007_add_filecoin_wallet",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1742774400000,
+      "tag": "0008_backfill_payment_chain",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/uploads-table.ts
+++ b/server/src/db/uploads-table.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, lte, sql } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNull, lte, or, sql } from 'drizzle-orm'
 import { PaginationContext } from '../types.js'
 import { logger } from '../utils/logger.js'
 import { db } from './db.js'
@@ -33,25 +33,22 @@ export const getUserHistory = async (
     const userAddress = wallet
     const offset = (page - 1) * limit
 
+    // before the payment_chain integration, all transactions, by default should be SOL
+    // so backfilling all NULL columns is neccessary
+    const paymentChainFilter =
+      chain === 'sol'
+        ? or(eq(uploads.paymentChain, chain), isNull(uploads.paymentChain))
+        : eq(uploads.paymentChain, chain)
+
     const [{ count }] = await db
       .select({ count: sql<number>`count(*)` })
       .from(uploads)
-      .where(
-        and(
-          eq(uploads.depositKey, userAddress),
-          eq(uploads.paymentChain, chain),
-        ),
-      )
+      .where(and(eq(uploads.depositKey, userAddress), paymentChainFilter))
 
     const data = await db
       .select()
       .from(uploads)
-      .where(
-        and(
-          eq(uploads.depositKey, userAddress),
-          eq(uploads.paymentChain, chain),
-        ),
-      )
+      .where(and(eq(uploads.depositKey, userAddress), paymentChainFilter))
       .orderBy(desc(uploads.createdAt))
       .limit(limit)
       .offset(offset)

--- a/ui/src/components/skeletons/index.ts
+++ b/ui/src/components/skeletons/index.ts
@@ -1,1 +1,2 @@
+export * from './renewal'
 export * from './storage-cost'

--- a/ui/src/components/skeletons/renewal.tsx
+++ b/ui/src/components/skeletons/renewal.tsx
@@ -1,0 +1,160 @@
+import { Box, HStack, SimpleGrid, Skeleton, VStack } from '@chakra-ui/react'
+
+const skeletonProps = {
+  startColor: 'var(--bg-secondary)',
+  endColor: 'var(--border-hover)',
+}
+
+const CardShell = ({ children }: { children: React.ReactNode }) => (
+  <Box
+    p="1.5em"
+    bg="var(--bg-dark)"
+    border="1px solid var(--border-hover)"
+    borderRadius="var(--radius-lg)"
+    w="100%"
+  >
+    {children}
+  </Box>
+)
+
+const CardHeader = ({ width }: { width: string }) => (
+  <HStack spacing=".75em" mb="1.5em">
+    <Skeleton
+      height="24px"
+      width="24px"
+      borderRadius="4px"
+      {...skeletonProps}
+    />
+    <Skeleton
+      height="20px"
+      width={width}
+      borderRadius="6px"
+      {...skeletonProps}
+    />
+  </HStack>
+)
+
+const SkeletonRow = ({
+  labelW = '90px',
+  valueW = '120px',
+}: {
+  labelW?: string
+  valueW?: string
+}) => (
+  <HStack justify="space-between">
+    <Skeleton
+      height="20px"
+      width={labelW}
+      borderRadius="6px"
+      {...skeletonProps}
+    />
+    <Skeleton
+      height="20px"
+      width={valueW}
+      borderRadius="6px"
+      {...skeletonProps}
+    />
+  </HStack>
+)
+
+export const RenewalSkeleton = () => {
+  return (
+    <VStack spacing="2em" align="stretch" w="90%" maxW="640px">
+      <HStack spacing="0.5em">
+        <Skeleton
+          height="16px"
+          width="16px"
+          borderRadius="3px"
+          {...skeletonProps}
+        />
+        <Skeleton
+          height="20px"
+          width="110px"
+          borderRadius="6px"
+          {...skeletonProps}
+        />
+      </HStack>
+
+      <CardShell>
+        <CardHeader width="100px" />
+        <VStack spacing="1em" align="stretch">
+          <SkeletonRow labelW="70px" valueW="140px" />
+          <SkeletonRow labelW="40px" valueW="60px" />
+          <SkeletonRow labelW="130px" valueW="90px" />
+          <SkeletonRow labelW="50px" valueW="110px" />
+        </VStack>
+      </CardShell>
+
+      <CardShell>
+        <CardHeader width="140px" />
+        <SimpleGrid columns={{ base: 2, md: 4 }} spacing="1em" mb="1.5em">
+          {[0, 1, 2, 3].map((i) => (
+            <Skeleton
+              key={i}
+              height="48px"
+              borderRadius="var(--radius-md)"
+              {...skeletonProps}
+            />
+          ))}
+        </SimpleGrid>
+        <HStack spacing=".75em">
+          <Skeleton
+            height="20px"
+            width="50px"
+            borderRadius="6px"
+            {...skeletonProps}
+          />
+          <Skeleton
+            height="44px"
+            flex="1"
+            borderRadius="var(--radius-md)"
+            {...skeletonProps}
+          />
+          <Skeleton
+            height="20px"
+            width="30px"
+            borderRadius="6px"
+            {...skeletonProps}
+          />
+        </HStack>
+      </CardShell>
+
+      <CardShell>
+        <CardHeader width="110px" />
+        <VStack spacing="1em" align="stretch">
+          <SkeletonRow labelW="60px" valueW="60px" />
+          <HStack justify="space-between" align="baseline">
+            <Skeleton
+              height="20px"
+              width="40px"
+              borderRadius="6px"
+              {...skeletonProps}
+            />
+            <VStack spacing="0.25em" align="flex-end">
+              <Skeleton
+                height="32px"
+                width="140px"
+                borderRadius="6px"
+                {...skeletonProps}
+              />
+              <Skeleton
+                height="16px"
+                width="80px"
+                borderRadius="6px"
+                {...skeletonProps}
+              />
+            </VStack>
+          </HStack>
+          <SkeletonRow labelW="100px" valueW="80px" />
+        </VStack>
+      </CardShell>
+
+      <Skeleton
+        height="48px"
+        width="100%"
+        borderRadius="var(--radius-lg)"
+        {...skeletonProps}
+      />
+    </VStack>
+  )
+}

--- a/ui/src/containers/app/renew.tsx
+++ b/ui/src/containers/app/renew.tsx
@@ -1,3 +1,9 @@
+import { RenewalSkeleton } from '@/components/skeletons'
+import { useAuthContext } from '@/hooks/context'
+import { useRenewalCost } from '@/hooks/renewal'
+import { useSolPrice } from '@/hooks/sol-price'
+import type { State } from '@/lib/types'
+import { formatSOL, formatUSD, IS_DEV } from '@/lib/utils'
 import {
   Box,
   Button,
@@ -22,18 +28,13 @@ import dayjs from 'dayjs'
 import useEmblaCarousel from 'embla-carousel-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
-import { useAuthContext } from '@/hooks/context'
-import { useFileDetails, useRenewalCost } from '@/hooks/renewal'
-import { useSolPrice } from '@/hooks/sol-price'
-import type { State } from '@/lib/types'
-import { formatSOL, formatUSD, IS_DEV } from '@/lib/utils'
 
 const DURATION_PRESETS = [7, 30, 90, 180]
 
 export const Renew = () => {
   const search = useSearch({ from: '/renew' })
   const navigate = useNavigate()
-  const { user, balance } = useAuthContext()
+  const { balance } = useAuthContext()
   const { publicKey, signTransaction } = useWallet()
   const { price: solPrice } = useSolPrice()
 
@@ -101,11 +102,6 @@ export const Renew = () => {
   const [customDuration, setCustomDuration] = useState('')
   const [state, setState] = useState<State>('idle')
 
-  const { data: fileDetails, error: fileError } = useFileDetails(
-    user || '',
-    activeCid,
-  )
-
   const {
     data: renewalCost,
     error: costError,
@@ -137,7 +133,7 @@ export const Renew = () => {
     return Math.max(0, diffDays)
   }
 
-  const daysRemaining = getDaysRemaining(fileDetails?.expiresAt)
+  const daysRemaining = getDaysRemaining(renewalCost?.currentExpirationDate)
   const isExpired = daysRemaining === 0
   const costInSOL = Number(renewalCost?.costInSOL || 0)
   const hasInsufficientBalance = balance !== null && costInSOL > balance
@@ -219,7 +215,7 @@ export const Renew = () => {
     )
   }
 
-  if (fileError) {
+  if (costError) {
     return (
       <VStack spacing="2em" align="stretch" w="90%" maxW="640px">
         <Box
@@ -242,8 +238,8 @@ export const Renew = () => {
               Unable to Load File
             </Text>
             <Text color="var(--text-muted)">
-              {fileError instanceof Error
-                ? fileError.message
+              {costError instanceof Error
+                ? costError.message
                 : 'Failed to fetch file details'}
             </Text>
             <Link to="/app/history">
@@ -257,7 +253,9 @@ export const Renew = () => {
     )
   }
 
-  return (
+  return isLoadingCost ? (
+    <RenewalSkeleton />
+  ) : (
     <VStack spacing="2em" align="stretch" w="90%" maxW="640px">
       <Link to="/app/history">
         <HStack
@@ -336,22 +334,24 @@ export const Renew = () => {
                 <HStack justify="space-between">
                   <Text color="var(--text-muted)">Filename:</Text>
                   <Text color="var(--text-inverse)">
-                    {fileDetails?.fileName || 'Unnamed'}
+                    {renewalCost?.fileDetails.fileName || 'Unnamed'}
                   </Text>
                 </HStack>
 
                 <HStack justify="space-between">
                   <Text color="var(--text-muted)">Size:</Text>
                   <Text color="var(--text-inverse)">
-                    {formatFileSize(fileDetails?.fileSize)}
+                    {formatFileSize(renewalCost?.fileDetails.fileSize ?? 0)}
                   </Text>
                 </HStack>
 
                 <HStack justify="space-between">
                   <Text color="var(--text-muted)">Current Expiration:</Text>
                   <Text color="var(--text-inverse)">
-                    {fileDetails?.expiresAt
-                      ? dayjs(fileDetails.expiresAt).format('DD/MM/YYYY')
+                    {renewalCost?.currentExpirationDate
+                      ? dayjs(renewalCost.currentExpirationDate).format(
+                          'DD/MM/YYYY',
+                        )
                       : 'N/A'}
                   </Text>
                 </HStack>
@@ -503,11 +503,7 @@ export const Renew = () => {
           </Text>
         </HStack>
 
-        {isLoadingCost ? (
-          <Box textAlign="center" py="2em">
-            <Text color="var(--text-muted)">Calculating cost...</Text>
-          </Box>
-        ) : costError ? (
+        {costError ? (
           <Text color="var(--error)">Failed to calculate cost</Text>
         ) : (
           <VStack spacing="1em" align="stretch">
@@ -576,28 +572,11 @@ export const Renew = () => {
         borderRadius="var(--radius-lg)"
         transition="all 0.2s ease"
         _hover={{
-          bg:
-            state === 'uploading' || !renewalCost || hasInsufficientBalance
-              ? undefined
-              : 'var(--primary-600)',
+          bg: 'var(--white)',
           transform:
             state === 'uploading' || !renewalCost || hasInsufficientBalance
               ? 'none'
               : 'translateY(-1px)',
-          boxShadow:
-            state === 'uploading' || !renewalCost || hasInsufficientBalance
-              ? undefined
-              : '0 4px 12px rgba(249, 115, 22, 0.4), 0 0 20px rgba(249, 115, 22, 0.2)',
-        }}
-        _active={{
-          transform:
-            state === 'uploading' || !renewalCost || hasInsufficientBalance
-              ? 'none'
-              : 'translateY(0)',
-          bg:
-            state === 'uploading' || !renewalCost || hasInsufficientBalance
-              ? undefined
-              : 'var(--primary-700)',
         }}
         _disabled={{
           bg: 'var(--bg-dark)',

--- a/ui/src/hooks/renewal.ts
+++ b/ui/src/hooks/renewal.ts
@@ -1,7 +1,7 @@
-import { useUpload } from '@toju.network/sol'
-import useSWR from 'swr'
 import { useAuthContext } from '@/hooks/context'
 import { IS_DEV } from '@/lib/utils'
+import { useUpload } from '@toju.network/sol'
+import useSWR from 'swr'
 
 export const useRenewalCost = (cid: string, duration: number) => {
   const { network } = useAuthContext()
@@ -11,34 +11,6 @@ export const useRenewalCost = (cid: string, duration: number) => {
   const { data, error, isLoading } = useSWR(key, async () => {
     const renewalCost = await client.getStorageRenewalCost(cid, duration)
     return renewalCost
-  })
-
-  return {
-    data,
-    error,
-    isLoading,
-  }
-}
-
-export const useFileDetails = (walletAddress: string, cid: string) => {
-  const { network } = useAuthContext()
-  const client = useUpload(network, IS_DEV)
-  const key =
-    walletAddress && cid ? ['file-details', walletAddress, cid, network] : null
-
-  const { data, error, isLoading } = useSWR(key, async () => {
-    const response = await client.getUserUploadHistory(walletAddress, 1, 100)
-    const file = response.data?.find((f: any) => f.contentCid === cid)
-
-    if (!file) {
-      throw new Error('File not found in your upload history')
-    }
-
-    if (file.deletionStatus === 'deleted') {
-      throw new Error('This file has been deleted and cannot be renewed')
-    }
-
-    return file
   })
 
   return {


### PR DESCRIPTION
the renewal page was showing "unable to load file" because `useFileDetails` was fetching file metadata by scanning upload history, keyed on the user's wallet address. if the address wasn't resolved yet, the hook silently never fired. and even when it did, pre-chain-integration uploads had NULL `payment_chain` and were excluded from the query result.

removed useFileDetails entirely — the renewal cost endpoint already returns file metadata, so now it reads `fileName`, `fileSize`, and expiration directly from useRenewalCost. also added the 0008 backfill migration to set `payment_chain` on all NULL rows, fixing the history filter for old SOL uploads.